### PR TITLE
add "acl" kwarg to service definition

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -42,6 +42,7 @@ class Service(object):
         self.defined_methods = []
         self.route_name = self.route_pattern
         self.renderer = kw.pop('renderer', 'simplejson')
+        self.acl_factory = kw.pop('acl')
         self.kw = kw
         self._defined = False
 
@@ -61,8 +62,19 @@ class Service(object):
 
         if not self._defined:
             # defining the route
-            config.add_route(self.route_name, self.route_pattern)
+            route_kw = {}
+            if self.acl_factory is not None:
+                route_kw["factory"] = self._make_route_factory()
+            config.add_route(self.route_name, self.route_pattern, **route_kw)
             self._defined = True
+
+    def _make_route_factory(self):
+        acl_factory = self.acl_factory
+        class ACLResource(object):
+            def __init__(self, request):
+                self.request = request
+                self.__acl__ = acl_factory(request)
+        return ACLResource
 
     #
     # Aliases for the three most common verbs


### PR DESCRIPTION
As discussed on services-dev.

This removes some of the boilerplate of specifying a custom access
control list. Pass in a function that takes a request and returns an
ACL, and that ACL will be applied to all views in the service.

Thoughts?
