### PR TITLE
Remove singleton "_defined" state from Service class.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 0.3 - ?
 =======
 
-??
+- remove singleton "_defined" state from Service class; this allows service
+  definitions to be loaded into more than one Configurator.
 
 0.2 - 2011-11-05
 ================

--- a/cornice/service.py
+++ b/cornice/service.py
@@ -49,7 +49,6 @@ class Service(object):
             self.description = None
         self.acl_factory = kw.pop('acl', None)
         self.kw = kw
-        self._defined = False
 
     def __repr__(self):
         return "<%s Service at %s>" % (self.renderer.capitalize(),
@@ -58,20 +57,18 @@ class Service(object):
     def _define(self, config, method):
         # setup the services hash if it isn't already
         services = config.registry.setdefault('cornice_services', {})
+
+        # define the route if it isn't already
         if self.route_pattern not in services:
             services[self.route_pattern] = self
-
-        # registring the method
-        if method not in self.defined_methods:
-            self.defined_methods.append(method)
-
-        if not self._defined:
-            # defining the route
             route_kw = {}
             if self.acl_factory is not None:
                 route_kw["factory"] = self._make_route_factory()
             config.add_route(self.route_name, self.route_pattern, **route_kw)
-            self._defined = True
+
+        # registering the method
+        if method not in self.defined_methods:
+            self.defined_methods.append(method)
 
     def _make_route_factory(self):
         acl_factory = self.acl_factory

--- a/cornice/tests/test_service_definition.py
+++ b/cornice/tests/test_service_definition.py
@@ -1,0 +1,83 @@
+
+import unittest
+import json
+from StringIO import StringIO
+
+from pyramid import testing
+from pyramid.exceptions import HTTPNotFound
+
+from cornice import Service
+
+
+service1 = Service(name="service1", path="/service1")
+
+@service1.get()
+def get1(request):
+    return {"test": "succeeded"}
+
+
+@service1.post()
+def post1(request):
+    return {"body": request.body}
+
+
+def make_request(**kwds):
+    environ = {}
+    environ["wsgi.version"] = (1, 0)
+    environ["wsgi.url_scheme"] = "http"
+    environ["SERVER_NAME"] = "localhost"
+    environ["SERVER_PORT"] = "80"
+    environ["REQUEST_METHOD"] = "GET"
+    environ["SCRIPT_NAME"] = ""
+    environ["PATH_INFO"] = "/"
+    environ.update(kwds)
+    return testing.DummyRequest(environ=environ)
+
+
+class TestServiceDefinition(unittest.TestCase):
+
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include("cornice")
+        self.config.scan("cornice.tests.test_service_definition")
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_basic_service_operation(self):
+        app = self.config.make_wsgi_app()
+
+        # An unknown URL raises HTTPNotFound
+        def start_response(status, headers, exc_info=None):
+            pass
+        req = make_request(PATH_INFO="/unknown")
+        self.assertRaises(HTTPNotFound, app, req.environ, start_response)
+
+        # A request to the service calls the apppriate view function.
+        req = make_request(PATH_INFO="/service1")
+        result = json.loads("".join(app(req.environ, start_response)))
+        self.assertEquals(result["test"], "succeeded")
+
+        req = make_request(PATH_INFO="/service1", REQUEST_METHOD="POST")
+        req.environ["wsgi.input"] = StringIO("BODY")
+        result = json.loads("".join(app(req.environ, start_response)))
+        self.assertEquals(result["body"], "BODY")
+
+    def test_loading_into_multiple_configurators(self):
+        config2 = testing.setUp()
+        config2.include("cornice")
+        config2.scan("cornice.tests.test_service_definition")
+
+        # Calling the new configurator works as expected.
+        def start_response(status, headers, exc_info=None):
+            pass
+        app = config2.make_wsgi_app()
+        req = make_request(PATH_INFO="/service1")
+        result = json.loads("".join(app(req.environ, start_response)))
+        self.assertEquals(result["test"], "succeeded")
+
+        # Calling the old configurator works as expected.
+        app = self.config.make_wsgi_app()
+        req = make_request(PATH_INFO="/service1")
+        result = json.loads("".join(app(req.environ, start_response)))
+        self.assertEquals(result["test"], "succeeded")


### PR DESCRIPTION
Keeping a single "I have been defined" marker prevented service
definitions from being loaded into more than one Configurator.
This patch uses the registry to track whether the service has been
defined on each individual Configurator object.
