### PR TITLE
try to parse data from the request body only if there is one

### DIFF
--- a/cornice/tests/test_service_description.py
+++ b/cornice/tests/test_service_description.py
@@ -58,8 +58,16 @@ class FooBarSchema(MappingSchema):
     yeah = SchemaNode(String(), location="querystring", type='str')
 
 
+class SchemaFromQuerystring(MappingSchema):
+    yeah = SchemaNode(String(), location="querystring", type='str') 
+
+
 @foobar.post(schema=FooBarSchema)
 def foobar_post(request):
+    return {"test": "succeeded"}
+
+@foobar.get(schema=SchemaFromQuerystring)
+def foobar_get(request):
     return {"test": "succeeded"}
 
 
@@ -97,7 +105,7 @@ class TestServiceDescription(unittest.TestCase):
                                   if e['location'] == "querystring"]))
 
         # ... and 4 in the body (a json error as well)
-        self.assertEquals(4, len([e for e in errors
+        self.assertEquals(3, len([e for e in errors
                                   if e['location'] == "body"]))
 
 
@@ -115,3 +123,8 @@ class TestServiceDescription(unittest.TestCase):
                              status=200)
 
         self.assertEquals(resp.json, {"test": "succeeded"})
+
+
+    def test_schema_validation2(self):
+        resp = self.app.get('/foobar?yeah=test', status=200)
+        self.assertEquals(resp.json, {"test": "succeeded"})        

--- a/cornice/util.py
+++ b/cornice/util.py
@@ -41,6 +41,7 @@ def rst2html(data):
     return core.publish_string(data, writer=_FragmentWriter())
 
 
+
 def rst2node(data):
     """Converts a reStructuredText into its node
     """
@@ -108,10 +109,13 @@ def extract_request_data(request):
     them as a list of (querystring, headers, body, path)
     """
     # XXX In the body, we're only handling JSON for now.
-    try:
-        body = json.loads(request.body)
-    except ValueError, e:
-        request.errors.add('body', None, e.message)
+    if request.body:
+        try:
+            body = json.loads(request.body)
+        except ValueError, e:
+            request.errors.add('body', None, e.message)
+            body = {}
+    else:
         body = {}
 
     return request.GET, request.headers, body, request.matchdict


### PR DESCRIPTION
to make schema validation work for GET requests, too, parsing the request body must be optional.
