### PR TITLE
Add support for the OPTIONS HTTP verb

### DIFF
--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -42,7 +42,7 @@ def resource(**kw):
                                                        **service_args)
 
             # initialize views
-            for verb in ('get', 'post', 'put', 'delete'):
+            for verb in ('get', 'post', 'put', 'delete', 'options'):
                 view_attr = prefix + verb
                 meth = getattr(klass, view_attr, None)
                 if meth is not None:

--- a/cornice/service.py
+++ b/cornice/service.py
@@ -134,6 +134,9 @@ class Service(object):
     def delete(self, **kw):
         return self.api(request_method='DELETE', **kw)
 
+    def options(self, **kw):
+        return self.api(request_method='OPTIONS', **kw)
+
     def get_view_wrapper(self, kw):
         """
         Overload this method if you would like to wrap the API function


### PR DESCRIPTION
My application needs CORS support and that means I need to have an OPTIONS verb. I think this is pretty common in today REST services so I guess is worthy to add it to Cornice.

Prior to Cornice 0.7 I used to have a Service sublcass like this:

``` python
class CORSService(Service):

    def options(self, **kw):
        return self.api(request_method='OPTIONS', **kw)
```

but starting with Cornice 0.7 I switched to the nicer resource class based API. Unfortunately you can not use custom Service classes with resources. I started adding support for that and then I thought that just adding the options convenience method to the Service class was much simpler and cleaner.

What do you think?
