### PR TITLE
Updated .egg ignore pattern.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ lib
 include
 bin
 deps
-*.egg-info
+*.egg*
 *.swp
 html
 doc/build


### PR DESCRIPTION
Updated ignore pattern to ignore *.egg and *.egg-info directories. *.egg directories are created when installing the test_requires.
