### PR TITLE
Added waitress to project template.

### DIFF
--- a/cornice/scaffolds/cornice/setup.py_tmpl
+++ b/cornice/scaffolds/cornice/setup.py_tmpl
@@ -26,7 +26,7 @@ setup(name='{{project}}',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['cornice', 'PasteScript'],
+    install_requires=['cornice', 'PasteScript', 'waitress'],
     entry_points = """\
     [paste.app_factory]
     main = {{package}}:main


### PR DESCRIPTION
Pyramid 1.3 switched from paste.httpserver to waitress as development server
because the former is not compatible with Python 3.
