### PR TITLE
Make 'services' optional in Sphinx documentation

### DIFF
--- a/cornice/sphinxext.py
+++ b/cornice/sphinxext.py
@@ -62,7 +62,7 @@ class ServiceDirective(Directive):
         for module in self.options.get('modules'):
             import_module(module)
 
-        names = self.options.get('services')
+        names = self.options.get('services', [])
 
         service = self.options.get('service')
         if service is not None:


### PR DESCRIPTION
Right now "serrvices" must be defined although the documentation does not specify that and leaving it out crashes the documentation generation.

Please consider for pull.

Thanks.
