### PR TITLE
Fix auto-define of HEAD views from GET views.

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -221,12 +221,16 @@ class Service(object):
         if hasattr(self, 'get_view_wrapper'):
             view = self.get_view_wrapper(kwargs)(view)
         self.definitions.append((method, view, args))
-        if method == 'get':
-            self.definitions.append(('head', view, args))
-
         # keep track of the defined methods for the service
         if method not in self.defined_methods:
             self.defined_methods.append(method)
+
+        # auto-define a HEAD method if we have a definition for GET.
+        if method == 'GET':
+            self.definitions.append(('HEAD', view, args))
+            if 'HEAD' not in self.defined_methods:
+                self.defined_methods.append('HEAD')
+
 
     def decorator(self, method, **kwargs):
         """Add the ability to define methods using python's decorators

--- a/cornice/tests/test_service.py
+++ b/cornice/tests/test_service.py
@@ -98,8 +98,11 @@ class TestService(TestCase):
         def get_favorite_color(request):
             return "blue, hmm, red, hmm, aaaaaaaah"
 
+        self.assertEquals(2, len(service.definitions))
         method, view, _ = service.definitions[0]
         self.assertEquals(("GET", get_favorite_color), (method, view))
+        method, view, _ = service.definitions[1]
+        self.assertEquals(("HEAD", get_favorite_color), (method, view))
 
         @service.post(accept='text/plain', renderer='plain')
         @service.post(accept='application/json')
@@ -108,13 +111,13 @@ class TestService(TestCase):
 
         # using multiple decorators on a resource should register them all in
         # as many different definitions in the service
-        self.assertEquals(3, len(service.definitions))
+        self.assertEquals(4, len(service.definitions))
 
         @service.patch()
         def patch_favorite_color(request):
             return ""
 
-        method, view, _ = service.definitions[3]
+        method, view, _ = service.definitions[4]
         self.assertEquals("PATCH", method)
 
     def test_get_acceptable(self):
@@ -183,7 +186,7 @@ class TestService(TestCase):
                           klass=TemperatureCooler)
         service.add_view("get", "get_fresh_air")
 
-        self.assertEquals(len(service.definitions), 1)
+        self.assertEquals(len(service.definitions), 2)
 
         method, view, args = service.definitions[0]
         self.assertEquals(view, "get_fresh_air")


### PR DESCRIPTION
There appears to be some logic in cornice that auto-defines a HEAD method whenever a GET method is defined.  However, it never actually triggers, because the conditional checks a lower-case "get" against an uppercased method string "GET".

This patch fixes things so that it triggers, and adjusts the tests to account for this behaviour.
