### PR TITLE
implement "415 Unsupported Media Type"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 0.14 - XXXX-XX-XX
 =================
 
--  ???
+- Add validation of the ``Content-Type`` header sent in requests against a list of allowed ingress content types
+- ???
 
 0.13 - 2013-02-12
 =================

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,7 +2,8 @@ Here is a (alphabetically-ordered) list of the people who contributed to
 Cornice:
 
 * Alexis Metaireau <alexis@notmyidea.org>
-* Andre Caron <alexis@notmyidea.org>
+* Andre Caron <andre.l.caron@gmail.com>
+* Andreas Motl <andreas.motl@ilo.de>
 * Anton D <anton@screwtop>
 * Ben Bangert <ben@groovie.org>
 * Bruno Binet <bruno.binet@gmail.com>
@@ -15,7 +16,7 @@ Cornice:
 * Marcin Lulek <info@webreactor.eu>
 * Marconi Moreto <caketoad@gmail.com>
 * Markus Zapke-Gründemann <markus@keimlink.de>
-* matthias <matthias@itemfire.com>
+* Matthias Wahl <matthias@itemfire.com>
 * Rémy HUBSCHER <hubscher.remy@gmail.com>
 * rforkel <rforkel@rforkel-ubuntu.gulp.biz>
 * Rob Miller <rafrombrc@gmail.com>

--- a/cornice/__init__.py
+++ b/cornice/__init__.py
@@ -11,6 +11,7 @@ from cornice.pyramidhook import (
     register_service_views,
     handle_exceptions
 )
+from cornice.util import ContentTypePredicate
 
 logger = logging.getLogger('cornice')
 __version__ = 0.14
@@ -38,3 +39,4 @@ def includeme(config):
     config.add_subscriber(wrap_request, NewRequest)
     config.add_renderer('simplejson', util.json_renderer)
     config.add_view(handle_exceptions, context=Exception)
+    config.add_view_predicate('content_type', ContentTypePredicate)

--- a/cornice/tests/test_service.py
+++ b/cornice/tests/test_service.py
@@ -136,17 +136,71 @@ class TestService(TestCase):
         service.add_view("POST", lambda x: "ok", accept=('foo/bar'))
         self.assertEqual(service.get_acceptable("GET"),
                           ['text/plain', 'application/json'])
-        # and of course the list of accepted content-types  should be available
+        # and of course the list of accepted egress content-types should be available
         # for the "POST" as well.
         self.assertEqual(service.get_acceptable("POST"),
                           ['foo/bar'])
 
-        # it is possible to give acceptable content-types dynamically at
+        # it is possible to give acceptable egress content-types dynamically at
         # run-time. You don't always want to have the callables when retrieving
         # all the acceptable content-types
         service.add_view("POST", lambda x: "ok", accept=lambda r: "text/json")
         self.assertEqual(len(service.get_acceptable("POST")), 2)
         self.assertEqual(len(service.get_acceptable("POST", True)), 1)
+
+    def test_get_contenttypes(self):
+        # defining a service with different "content_type" headers, we should be able
+        # to retrieve this information easily
+        service = Service("color", "/favorite-color")
+        service.add_view("GET", lambda x: "blue", content_type="text/plain")
+        self.assertEquals(service.get_contenttypes("GET"), ['text/plain'])
+
+        service.add_view("GET", lambda x: "blue", content_type="application/json")
+        self.assertEquals(service.get_contenttypes("GET"),
+                          ['text/plain', 'application/json'])
+
+        # adding a view for the POST method should not break everything :-)
+        service.add_view("POST", lambda x: "ok", content_type=('foo/bar'))
+        self.assertEquals(service.get_contenttypes("GET"),
+                          ['text/plain', 'application/json'])
+        # and of course the list of supported ingress content-types should be available
+        # for the "POST" as well.
+        self.assertEquals(service.get_contenttypes("POST"),
+                          ['foo/bar'])
+
+        # it is possible to give supported ingress content-types dynamically at
+        # run-time. You don't always want to have the callables when retrieving
+        # all the supported content-types
+        service.add_view("POST", lambda x: "ok", content_type=lambda r: "text/json")
+        self.assertEquals(len(service.get_contenttypes("POST")), 2)
+        self.assertEquals(len(service.get_contenttypes("POST", True)), 1)
+
+    def test_get_contenttypes(self):
+        # defining a service with different "content_type" headers, we should be able
+        # to retrieve this information easily
+        service = Service("color", "/favorite-color")
+        service.add_view("GET", lambda x: "blue", content_type="text/plain")
+        self.assertEqual(service.get_contenttypes("GET"), ['text/plain'])
+
+        service.add_view("GET", lambda x: "blue", content_type="application/json")
+        self.assertEqual(service.get_contenttypes("GET"),
+                          ['text/plain', 'application/json'])
+
+        # adding a view for the POST method should not break everything :-)
+        service.add_view("POST", lambda x: "ok", content_type=('foo/bar'))
+        self.assertEqual(service.get_contenttypes("GET"),
+                          ['text/plain', 'application/json'])
+        # and of course the list of supported ingress content-types should be available
+        # for the "POST" as well.
+        self.assertEqual(service.get_contenttypes("POST"),
+                          ['foo/bar'])
+
+        # it is possible to give supported ingress content-types dynamically at
+        # run-time. You don't always want to have the callables when retrieving
+        # all the supported content-types
+        service.add_view("POST", lambda x: "ok", content_type=lambda r: "text/json")
+        self.assertEqual(len(service.get_contenttypes("POST")), 2)
+        self.assertEqual(len(service.get_contenttypes("POST", True)), 1)
 
     def test_get_validators(self):
         # defining different validators for the same services, even with

--- a/cornice/tests/validationapp.py
+++ b/cornice/tests/validationapp.py
@@ -107,6 +107,31 @@ filtered_service = Service(name="filtered", path="/filtered", filters=_filter)
 def get4(request):
     return "unfiltered"  # should be overwritten on GET
 
+
+# test the "content_type" parameter (scalar)
+service5 = Service(name="service5", path="/service5")
+@service5.get()
+@service5.post(content_type='application/json')
+@service5.put(content_type=('text/plain', 'application/json'))
+def post5(request):
+    return "some response"
+
+# test the "content_type" parameter (callable)
+service6 = Service(name="service6", path="/service6")
+def _content_type(request):
+    return ('text/xml', 'application/json')
+@service6.post(content_type=_content_type)
+def post6(request):
+    return {"body": "yay!"}
+
+# test a mix of "accept" and "content_type" parameters
+service7 = Service(name="service7", path="/service7")
+@service7.post(accept='text/xml', content_type='application/json')
+@service7.put(accept=('text/xml', 'text/plain'), content_type=('application/json', 'text/xml'))
+def post7(request):
+    return "some response"
+
+
 try:
     from colander import (
         Invalid,

--- a/docs/source/exhaustive_list.rst
+++ b/docs/source/exhaustive_list.rst
@@ -8,9 +8,9 @@ does it for you without noticing.
 Errors
 ======
 
-When valitating contents, cornice will automatically throw a 400 error if the
+When validating contents, cornice will automatically throw a 400 error if the
 data is invalid. Along with the 400 error, the body will contain a JSON dict
-which can be parsed to know more about the problems ecountered.
+which can be parsed to know more about the problems encountered.
 
 Method not allowed
 ==================
@@ -24,15 +24,25 @@ Authorization
 
 Authorization can be done using the `acl` parameter. If the authentication or
 the authorization fails at this stage, a 401 or 403 error is returned,
-depending the cases.
+depending on the cases.
 
-Content Types
-=============
+Content Types (ingress)
+=======================
 
-Each method can specify a list of content types it can handle. Per default,
-`text/html` is assumed. In the case the client requests an invalid content
-type, cornice will return a `406, Not Acceptable` with a list of available
-content types for the particular URI and method.
+Each method can specify a list of content types it can receive. Per default,
+any content type is allowed. In the case the client sends a request with an
+invalid `Content-Type` header, cornice will return a
+`415 Unsupported Media Type` with an error message containing the list of
+valid request content types for the particular URI and method.
+
+Content Types (egress)
+======================
+
+Each method can specify a list of content types it can respond with.
+Per default, `text/html` is assumed. In the case the client requests an
+invalid content type via `Accept` header, cornice will return a
+`406 Not Acceptable` with an error message containing the list of available
+response content types for the particular URI and method.
 
 Warning when returning JSON lists
 =================================

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -46,6 +46,7 @@ The default returned JSON object is a dictionary of the following form::
         'errors': errors.
     }
 
+
 With errors being a JSON dictionary with the keys "location", "name" and
 "description".
 
@@ -222,10 +223,94 @@ This means something like this::
         return "ok"
 
 
-Content-Type validation
-=======================
+Content validation
+==================
 
-Cornice can automatically deal with content type validation for you.
+There are two flavors of content validations cornice can apply to services:
+
+    - **Content-Type validation** will match the ``Content-Type`` header sent
+      by the client against a list of allowed content types.
+      When failing on that, it will croak with a ``415 Unsupported Media Type``.
+
+    - **Content negotiation** checks if cornice is able to respond with the
+      requested content type asked by the client sending an ``Accept`` header.
+      Otherwise it will croak with a ``406 Not Acceptable``.
+
+
+Content validation
+==================
+
+There are two flavors of content validations cornice can apply to services:
+
+    - **Content-Type validation** will match the ``Content-Type`` header sent
+      by the client against a list of allowed content types.
+      When failing on that, it will croak with a ``415 Unsupported Media Type``.
+
+    - **Content negotiation** checks if cornice is able to respond with the
+      requested content type asked by the client sending an ``Accept`` header.
+      Otherwise it will croak with a ``406 Not Acceptable``.
+
+
+Content-Type validation
+-----------------------
+
+You can specify a list of allowed ingress content types using the
+`content_type` argument to the decorator, like this::
+
+    @service.post(content_type="application/json")
+    def foo(request):
+        return 'Foo'
+
+In case the client sends a request with a disallowed header - e.g.
+``Content-Type: application/x-www-form-urlencoded`` -
+cornice will reject the request with a http status of
+``415 Unsupported Media Type``.
+
+Additionally, a list of valid content types is sent using the configured
+`error_handler`. When using the default json `error_handler`, the response
+might look like this::
+
+    {
+        'status': 'error',
+        'errors': [
+            {
+                'location': 'header',
+                'name': 'Content-Type',
+                'description': 'Content-Type header should be one of ["application/json"]'
+            }
+        ]
+    }
+
+
+The `content_type` argument can either be a callable, a string or a list of
+accepted values. When a callable is specified, it is called *before* the
+request is passed to the destination function, with the `request` object as
+an argument.
+
+The callable should return a list of accepted content types::
+
+    def _content_type(request):
+        # interact with request if needed
+        return ("text/xml", "application/json")
+
+    @service.post(content_type=_content_type)
+    def foo(request):
+        return 'Foo'
+
+The match is done against the plain internet media type string without
+additional parameters like ``charset=utf-8`` or the like.
+
+.. seealso::
+
+    "Return the content type, but leaving off any parameters."
+
+    -- http://docs.webob.org/en/latest/modules/webob.html#webob.request.BaseRequest.content_type
+
+
+Content negotiation
+-------------------
+
+Cornice can automatically deal with egress content negotiation for you.
 If you want it to, you have to pass the `accept` argument to the decorator,
 like this::
 
@@ -237,8 +322,8 @@ In case the client sends a request, asking for some particular content types
 (using the HTTP **Accept** header), cornice will check that it is able to 
 handle it.
 
-If not, it will return a 406 HTTP code, with the list of accepted
-content types.
+If not, it will respond with a http status of ``406 Not Acceptable``. The body
+is an error message containing the list of available response content types.
 
 The `accept` argument can either be a callable, a string or a list of accepted
 values. When a callable is specified, it is called *before* the request is
@@ -253,6 +338,9 @@ The callable should return a list of accepted content types::
     @service.get(accept=_accept)
     def foo(request):
         return 'Foo'
+
+.. seealso:: https://developer.mozilla.org/en-US/docs/HTTP/Content_negotiation
+
 
 Managing ACLs
 =============


### PR DESCRIPTION
This implements validation of the `Content-Type` header sent in requests against a list of allowed content types and responds with "415 Unsupported Media Type", if there's a mismatch. Could resolve #57. ;]
