### PR TITLE
Only require unittest2 on Python < 2.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from setuptools import setup, find_packages
 
@@ -10,8 +11,11 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
 requires = ['pyramid',  'simplejson']
-test_requires = requires + ['colander', 'unittest2', 'coverage',
+test_requires = requires + ['colander', 'coverage',
                             'webtest', 'Sphinx', 'rxjson']
+
+if sys.version_info < (2, 7):
+    test_requires.append('unittest2')
 
 try:
     import importlib  # NOQA


### PR DESCRIPTION
This helps with Python 3 compatibility since `unittest2` fails to install on Python 3.

I am planning to take some of the ideas out of #94 and make them into separate PRs that are less controversial and easier to understand and accept one at a time.
