### PR TITLE
.travis.yml: Add "install" step that does `pip install --use-mirrors .`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
     - "2.6"
     - "2.7"
+install: pip install --use-mirrors .
 script: python setup.py test
 notifications:
     irc:


### PR DESCRIPTION
so that package installs are more likely to succeed.

I noticed while submitting other pull requests that the Travis builds kept failing because it was failing to download `Chameleon` -- I think that PyPI or their site is having trouble. It seems that doing `pip install --use-mirrors` helps the download to succeed.
