### PR TITLE
Doc fix: bug in example in quickstart

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -51,7 +51,7 @@ The :file:`views` module can look like this::
         """
         key = request.matchdict['value']
         try:
-            _VALUES.set(key, json.loads(request.body))
+            _VALUES[key] = json.loads(request.body)
         except ValueError:
             return False
         return True


### PR DESCRIPTION
The example app in the quickstart docs has a bug: there's no .set() method on dicts.
