### PR TITLE
Fix typos in test in ffaa5b9b1ffb2575af8d305cc62f9757a5709f25 that masks the problem in issue #113.

### DIFF
--- a/cornice/tests/test_validation.py
+++ b/cornice/tests/test_validation.py
@@ -81,7 +81,7 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         self.assertTrue('text/json' in res.json)
 
         res = app.get('/service3', headers={'Accept': 'text/*'}, status=200)
-        self.assertTrue(r.content_type, "text/json")
+        self.assertEquals(res.content_type, "text/json")
 
         # if we are not asking for a particular content-type,
         # we should get the type defined by outermost declaration.


### PR DESCRIPTION
Fix typos in test in ffaa5b9b1ffb2575af8d305cc62f9757a5709f25 that masks the problem in issue #113.

The line was incorrect for two reasons:
1. It checks `r` rather than `res`.
2. It does `assertTrue` rather than `assertEquals`.
