### PR TITLE
tox.ini: Add ipdb, nose, WebTest as deps.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,9 @@
 envlist = py26,py27
 
 [testenv]
+deps =
+    ipdb
+    nose
+    WebTest
 commands =
     python setup.py test


### PR DESCRIPTION
This makes it easier to do stuff like:

```
.tox/py26/bin/nosetests -v cornice.tests.test_validation:TestServiceDefinition.test_accept
```

and set breakpoints with `import ipdb; ipdb.set_trace()`
