### PR TITLE
Colander: Support schema binding.

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -64,6 +64,8 @@ def validate_colander_schema(schema, request):
 
     def _validate_fields(location, data):
         for attr in schema.get_attributes(location=location):
+            attr = attr.bind(request=request)
+
             if attr.required and not attr.name in data:
                 # missing
                 request.errors.add(location, attr.name,

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -2,20 +2,32 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 from cornice.tests.support import TestCase
-from cornice.schemas import CorniceSchema
+from cornice.pyramidhook import wrap_request
+from cornice.schemas import CorniceSchema, validate_colander_schema
+from pyramid.events import NewRequest
+from pyramid.testing import DummyRequest
 
 try:
     from colander import (
         MappingSchema,
         SchemaNode,
         String,
-        Int
+        Int,
+        Length,
+        deferred
     )
     COLANDER = True
 except ImportError:
     COLANDER = False
 
 if COLANDER:
+
+    @deferred
+    def deferred_validator(node, kw):
+        """Limit `foo` node length via request header value"""
+        req = kw['request']
+        min_len = int(req.headers.get('x-foo-min-length', 0))
+        return Length(min_len)
 
     class TestingSchema(MappingSchema):
         foo = SchemaNode(String(), type='str')
@@ -24,6 +36,10 @@ if COLANDER:
 
     class InheritedSchema(TestingSchema):
         foo = SchemaNode(Int(), missing=1)
+
+    class DeferredSchema(MappingSchema):
+        foo = SchemaNode(String(), type='str', location='body',
+                         validator=deferred_validator)
 
     class TestSchemas(TestCase):
 
@@ -56,3 +72,16 @@ if COLANDER:
                                    inherited_schema.get_attributes())[0]
             self.assertTrue(base_foo.required)
             self.assertFalse(inherited_foo.required)
+
+        def test_colander_deferred_binding(self):
+            """
+            Support colander.deferred by binding request.
+            """
+            schema = CorniceSchema.from_colander(DeferredSchema)
+            request = DummyRequest(headers={'x-foo-min-length': 2}, body='{"foo": "x"}')
+            event = NewRequest(request)
+            wrap_request(event)
+
+            validate_colander_schema(schema, request)
+
+            self.assertEqual(len(request.errors), 1)

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -124,6 +124,9 @@ To describe a schema, using colander and cornice, here is how you can do::
 
 You can even use Schema-Inheritance as introduced by Colander 0.9.9.
 
+Schema binding is also supported by binding the active request object to the
+"request" key. See `Colander Binding`_ for more info.
+
 Using formencode
 ~~~~~~~~~~~~~~~~
 
@@ -276,3 +279,6 @@ In case you would like to register a filter for all the services but one, you
 can use the `exclude` parameter. It works either on services or on methods::
 
     @foo.get(exclude=your_callable)
+
+
+.. _Colander Binding: http://docs.pylonsproject.org/projects/colander/en/latest/binding.html


### PR DESCRIPTION
This commit adds support for Colander schema/deferred binding by binding the
active request. This causes any deferred values to be resolved, tripping
validation or other custom logic during deserialization.

---

My use case for this addition is to validate i.e., PUT, POST, etc. operations on entities by ensuring that the requester "owns" the object they're trying to modify. Rather than using dynamic ACLs or some unrelated method for this, it's nice to be able to stick with Colander.
