### PR TITLE
context factory support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 0.14 - XXXX-XX-XX
 =================
 
--  ???
+- add support for context factory.
 
 0.13 - 2013-02-12
 =================

--- a/cornice/service.py
+++ b/cornice/service.py
@@ -434,13 +434,16 @@ def decorate_view(view, args, method):
     :param args: the args to use for the decoration
     :param method: the HTTP method
     """
-    def wrapper(context, request):
+    def wrapper(request):
         # if the args contain a klass argument then use it to resolve the view
         # location (if the view argument isn't a callable)
         ob = None
         view_ = view
         if 'klass' in args:
-            ob = args['klass'](request=request, context=context)
+            params = dict(request=request)
+            if 'factory' in args and 'acl' not in args:
+                params['context'] = args['factory'](request)
+            ob = args['klass'](**params)
             if is_string(view):
                 view_ = getattr(ob, view.lower())
 


### PR DESCRIPTION
cornice 'abuses' the `factory` predicate to support ACLs. however, in our own use case we expected `factory` to provide a context for views, as is customary in pyramid.

this patch attempts a backward compatible approach. since the cornice docs state that the `args` and `factory` predicates require each other, we simply check like so:

``` python
if 'factory' in args and 'acl' not in args:
```

and then call the view with the result of the factory call and pass it in as `context`.

is this compromise acceptable? in the long run we'd argue that cornice should use a custom predicate such as `acl_factory` and leave the `factory` keyword for its 'officially' intended use, but that's perhaps a different issue.

if you agree, we're perfectly willing to add the required tests and update the documentation accordingly. at the moment this PR is just a probe to test the waters :-)
