### PR TITLE
fix and tests for "header" validation using CorniceSchema

### DIFF
--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -94,7 +94,7 @@ class ServiceDirective(Directive):
                 schema = args['schema']
 
                 attrs_node = nodes.inline()
-                for location in ('headers', 'querystring', 'body'):
+                for location in ('header', 'querystring', 'body'):
                     attributes = schema.get_attributes(location=location)
                     if attributes:
                         attrs_node += nodes.inline(

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -20,7 +20,7 @@ class CorniceSchema(object):
         else:
             self._attributes = schema.children
 
-    def get_attributes(self, location=("body", "headers", "querystring"),
+    def get_attributes(self, location=("body", "header", "querystring"),
                        required=(True, False),
                        request=None):
         """Return a list of attributes that match the given criteria.

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -56,6 +56,12 @@ if COLANDER:
     imperative_schema.add(SchemaNode(String(), name='baz', type='str',
                           location="querystring"))
 
+    class TestingSchemaWithHeader(MappingSchema):
+        foo = SchemaNode(String(), type='str')
+        bar = SchemaNode(String(), type='str', location="body")
+        baz = SchemaNode(String(), type='str', location="querystring")
+        qux = SchemaNode(String(), type='str', location="header")
+
     class TestSchemas(TestCase):
 
         def test_colander_integration(self):
@@ -66,6 +72,18 @@ if COLANDER:
 
             self.assertEquals(len(body_fields), 2)
             self.assertEquals(len(qs_fields), 1)
+
+        def test_colander_integration_with_header(self):
+            schema = CorniceSchema.from_colander(TestingSchemaWithHeader)
+            all_fields = schema.get_attributes()
+            body_fields = schema.get_attributes(location="body")
+            qs_fields = schema.get_attributes(location="querystring")
+            header_fields = schema.get_attributes(location="header")
+
+            self.assertEquals(len(all_fields), 4)
+            self.assertEquals(len(body_fields), 2)
+            self.assertEquals(len(qs_fields), 1)
+            self.assertEquals(len(header_fields), 1)
 
         def test_colander_inheritance(self):
             """


### PR DESCRIPTION
Validating a request header using a colander schema by defining a schema node with `location="header"` had problems. Bug is fixed and proper tests should assure it won't break in the future.

The fix is based on the assumption that Cornice should get consistent in naming the value of the location actually `header` instead of `headers`, which is reflected at ...
https://github.com/mozilla-services/cornice/blob/master/cornice/schemas.py#L108

... and in various other places, e.g.:

> location is the location of the error. It can be “querystring”, “header” or “body”
> -- http://cornice.readthedocs.org/en/latest/validation.html#dealing-with-errors

... and:
https://github.com/mozilla-services/cornice/blob/master/cornice/tests/test_pyramidhook.py#L47
