### PR TITLE
CORS should be reevaluated if a view returns a Response.

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -4,6 +4,7 @@
 import functools
 import warnings
 
+from pyramid.response import Response
 from cornice.validators import (
     DEFAULT_VALIDATORS,
     DEFAULT_FILTERS,
@@ -464,6 +465,11 @@ def decorate_view(view, args, method):
                 response = view_()
             else:
                 response = view_(request)
+
+            if isinstance(response, Response):
+                # We already checked for CORS, but since we got an actual
+                # Response, chances are the headers are missing.
+                request.info['cors_checked'] = False
 
         # check for errors and return them if any
         if len(request.errors) > 0:

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -41,6 +41,11 @@ def moar_spam(request):
     return 'moar spam'
 
 
+@spam.put()
+def spam_response(request):
+    return Response(status_code=202, json={'foo': 'bar'})
+
+
 def is_bacon_good(request):
     if not request.matchdict['type'].endswith('good'):
         request.errors.add('querystring', 'type', 'should be better!')
@@ -231,3 +236,8 @@ class TestCORS(TestCase):
         resp = self.app.get('/noservice', status=200,
                             headers={'Origin': 'notmyidea.org'})
         self.assertEquals(resp.body, b'No Service here.')
+
+    def test_CORS_headers_added_if_Response_returned(self):
+        resp = self.app.put('/spam', status=202,
+                            headers={'Origin': 'notmyidea.org'})
+        self.assertIn('Access-Control-Allow-Origin', resp.headers)


### PR DESCRIPTION
Pretty much what the test shows: I want to be able to return `Responses` with custom status codes, etc. from my views without incurring the opaque wrath of the browser's response-swallowing when CORS headers are missing.
