### PR TITLE
Fix docstring when defining a resource

### DIFF
--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -92,7 +92,7 @@ class ServiceDirective(Directive):
                 if 'klass' in args:
                     ob = args['klass']
                     view_ = getattr(ob, view.lower())
-                    docstring = view_.__doc__
+                    docstring = trim(view_.__doc__ or "") + '\n'
             else:
                 docstring = trim(view.__doc__ or "") + '\n'
 


### PR DESCRIPTION
When defining a resource docstrings aren't being picked up correctly.  'view' in _render_service is a string e.g. 'get'.  As such the docstring that gets rendered is from the string type:

"str(object) -> string\n\nReturn a nice string representation of the object.\nIf the argument is a string, the return value is the same object."

I've updated _render_service to use a similar pattern as services.decorate_view to get the correct docstring.
