### PR TITLE
The link in the documentation to the Pylons wiki is dead

### DIFF
--- a/docs/source/builtin-features.rst
+++ b/docs/source/builtin-features.rst
@@ -17,9 +17,10 @@ JSON XSRF filter
 The `cornice.validators.filter_json_xsrf` filter checks out the views response,
 looking for json objects returning lists.
 
-It happens that json lists are subject to cross request forgery attacks (XSRF)
-when returning lists (see http://wiki.pylonshq.com/display/pylonsfaq/Warnings), 
-so cornice will drop a warning in case you're doing so.
+It happens that json lists are subject to cross site request forgery attacks
+(XSRF) when returning lists (see
+http://haacked.com/archive/2009/06/25/json-hijacking.aspx), so cornice will
+drop a warning in case you're doing so.
 
 Built-in validators
 ===================

--- a/docs/source/exhaustive_list.rst
+++ b/docs/source/exhaustive_list.rst
@@ -38,8 +38,8 @@ Warning when returning JSON lists
 =================================
 
 JSON lists are subject to security threats, as defined
-`in this document <http://wiki.pylonshq.com/display/pylonsfaq/Warnings`. In
-case you return a javascript list, a warning will be thrown. It will not
+`in this document <http://haacked.com/archive/2009/06/25/json-hijacking.aspx`.
+In case you return a javascript list, a warning will be thrown. It will not
 however prevent you from returning the array.
 
 This behaviour can be disabled if needed (it can be removed from the list of


### PR DESCRIPTION
Going to wiki.pylonshq now causes a 502 gateway error.

This pull request changes the link to an article from 2009 about the vulnerability that isn't dead.
