### PR TITLE
Allow Colander schemas with sequence fields in querystring

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -76,7 +76,8 @@ class CorniceSchema(object):
 
 def validate_colander_schema(schema, request):
     """Validates that the request is conform to the given schema"""
-    from colander import Invalid
+    from colander import Invalid, Sequence
+
     def _validate_fields(location, data):
         for attr in schema.get_attributes(location=location,
                                           request=request):
@@ -89,7 +90,12 @@ def validate_colander_schema(schema, request):
                     if not attr.name in data:
                         deserialized = attr.deserialize()
                     else:
-                        deserialized = attr.deserialize(data[attr.name])
+                        if location == 'querystring'\
+                           and isinstance(attr.typ, Sequence):
+                            serialized = data.getall(attr.name)
+                        else:
+                            serialized = data[attr.name]
+                        deserialized = attr.deserialize(serialized)
                 except Invalid as e:
                     # the struct is invalid
                     try:

--- a/cornice/tests/test_validation.py
+++ b/cornice/tests/test_validation.py
@@ -161,3 +161,13 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
             resp.content_type = 'application/json'
             filter_json_xsrf(resp)
             assert len(self.get_logs()) == 0, "Unexpected warning: %s" % value
+
+    def test_multile_querystrings(self):
+
+        #schema = CorniceSchema.from_colander(ListQuerystringSequence)
+        #import ipdb; ipdb.set_trace()
+        app = TestApp(main({}))
+
+        # filters can be applied to all the methods of a service
+        self.assertEquals('{"field": ["5"]}', app.get('/foobaz?field=5').body)
+        self.assertEquals('{"field": ["5", "2"]}', app.get('/foobaz?field=5&field=2').body)

--- a/cornice/tests/validationapp.py
+++ b/cornice/tests/validationapp.py
@@ -140,10 +140,21 @@ if COLANDER:
         integers = Integers(location="body", type='list', missing=())
 
     foobar = Service(name="foobar", path="/foobar")
+    foobaz = Service(name="foobaz", path="/foobaz")
 
     @foobar.post(schema=FooBarSchema)
     def foobar_post(request):
         return {"test": "succeeded"}
+
+    class StringSequence(SequenceSchema):
+        _ = SchemaNode(String())
+
+    class ListQuerystringSequence(MappingSchema):
+        field = StringSequence(location="querystring")
+
+    @foobaz.get(schema=ListQuerystringSequence)
+    def foobaz_get(request):
+        return {"field": request.validated['field']}
 
 
 def includeme(config):


### PR DESCRIPTION
This allows to use multiple query string fields with the same name by
using a Colander SequenceSchema.

See `tests/validationapp.py` for an example.
