### PR TITLE
silence deprecation warnings on py3k: renamed "assertEquals" to "assertEqual"

### DIFF
--- a/cornice/tests/ext/test_sphinxext.py
+++ b/cornice/tests/ext/test_sphinxext.py
@@ -10,5 +10,5 @@ class TestUtil(TestCase):
     def test_rendering(self):
         text = '**simple render**'
         res = rst2html(text)
-        self.assertEquals(res, b'<p><strong>simple render</strong></p>')
-        self.assertEquals(rst2html(''), '')
+        self.assertEqual(res, b'<p><strong>simple render</strong></p>')
+        self.assertEqual(rst2html(''), '')

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -80,7 +80,7 @@ class TestCORS(TestCase):
         # "Access-Control-Request-Method"or without the "Origin" header,
         # we should get a 400.
         resp = self.app.options('/squirel', status=400)
-        self.assertEquals(len(resp.json['errors']), 2)
+        self.assertEqual(len(resp.json['errors']), 2)
 
     def test_preflight_missing_origin(self):
 
@@ -88,7 +88,7 @@ class TestCORS(TestCase):
             '/squirel',
             headers={'Access-Control-Request-Method': 'GET'},
             status=400)
-        self.assertEquals(len(resp.json['errors']), 1)
+        self.assertEqual(len(resp.json['errors']), 1)
 
     def test_preflight_missing_request_method(self):
 
@@ -97,7 +97,7 @@ class TestCORS(TestCase):
             headers={'Origin': 'foobar.org'},
             status=400)
 
-        self.assertEquals(len(resp.json['errors']), 1)
+        self.assertEqual(len(resp.json['errors']), 1)
 
     def test_preflight_incorrect_origin(self):
         # we put "lolnet.org" where only "notmyidea.org" is authorized
@@ -106,14 +106,14 @@ class TestCORS(TestCase):
             headers={'Origin': 'lolnet.org',
                      'Access-Control-Request-Method': 'GET'},
             status=400)
-        self.assertEquals(len(resp.json['errors']), 1)
+        self.assertEqual(len(resp.json['errors']), 1)
 
     def test_preflight_correct_origin(self):
         resp = self.app.options(
             '/squirel',
             headers={'Origin': 'notmyidea.org',
                      'Access-Control-Request-Method': 'GET'})
-        self.assertEquals(
+        self.assertEqual(
             resp.headers['Access-Control-Allow-Origin'],
             'notmyidea.org')
 
@@ -149,7 +149,7 @@ class TestCORS(TestCase):
                      'Access-Control-Request-Method': 'GET'})
 
         self.assertIn('Access-Control-Allow-Credentials', resp.headers)
-        self.assertEquals(resp.headers['Access-Control-Allow-Credentials'],
+        self.assertEqual(resp.headers['Access-Control-Allow-Credentials'],
                           'true')
 
     def test_preflight_credentials_header_not_included_when_not_needed(self):
@@ -165,23 +165,23 @@ class TestCORS(TestCase):
                          'Access-Control-Request-Method': 'GET'})
 
         self.assertIn('Access-Control-Max-Age', resp.headers)
-        self.assertEquals(resp.headers['Access-Control-Max-Age'], '42')
+        self.assertEqual(resp.headers['Access-Control-Max-Age'], '42')
 
     def test_resp_dont_include_allow_origin(self):
         resp = self.app.get('/squirel')  # omit the Origin header
         self.assertNotIn('Access-Control-Allow-Origin', resp.headers)
-        self.assertEquals(resp.json, 'squirels')
+        self.assertEqual(resp.json, 'squirels')
 
     def test_responses_include_an_allow_origin_header(self):
         resp = self.app.get('/squirel', headers={'Origin': 'notmyidea.org'})
         self.assertIn('Access-Control-Allow-Origin', resp.headers)
-        self.assertEquals(resp.headers['Access-Control-Allow-Origin'],
+        self.assertEqual(resp.headers['Access-Control-Allow-Origin'],
                           'notmyidea.org')
 
     def test_credentials_are_included(self):
         resp = self.app.get('/spam', headers={'Origin': 'notmyidea.org'})
         self.assertIn('Access-Control-Allow-Credentials', resp.headers)
-        self.assertEquals(resp.headers['Access-Control-Allow-Credentials'],
+        self.assertEqual(resp.headers['Access-Control-Allow-Credentials'],
                           'true')
 
     def test_headers_are_exposed(self):
@@ -230,4 +230,4 @@ class TestCORS(TestCase):
     def test_existing_non_service_route(self):
         resp = self.app.get('/noservice', status=200,
                             headers={'Origin': 'notmyidea.org'})
-        self.assertEquals(resp.body, b'No Service here.')
+        self.assertEqual(resp.body, b'No Service here.')

--- a/cornice/tests/test_pyramidhook.py
+++ b/cornice/tests/test_pyramidhook.py
@@ -81,7 +81,7 @@ class TestService(TestCase):
     def test_class_support(self):
         self.app.get('/fresh-air', status=400)
         resp = self.app.get('/fresh-air', headers={'X-Temperature': '50'})
-        self.assertEquals(resp.body, b'fresh air')
+        self.assertEqual(resp.body, b'fresh air')
 
 
 class WrapperService(Service):

--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -55,17 +55,17 @@ class TestResource(TestCase):
 
     def test_basic_resource(self):
 
-        self.assertEquals(self.app.get("/users").json, {'users': [1, 2]})
+        self.assertEqual(self.app.get("/users").json, {'users': [1, 2]})
 
-        self.assertEquals(self.app.get("/users/1").json, {'name': 'gawel'})
+        self.assertEqual(self.app.get("/users/1").json, {'name': 'gawel'})
 
         resp = self.app.get("/users/1?callback=test")
-        self.assertEquals(resp.body, b'test({"name": "gawel"})', resp.body)
+        self.assertEqual(resp.body, b'test({"name": "gawel"})', resp.body)
 
     def test_accept_headers(self):
         # the accept headers should work even in case they're specified in a
         # resource method
-        self.assertEquals(
+        self.assertEqual(
             self.app.post("/users", headers={'Accept': 'text/json'},
                           params=json.dumps({'test': 'yeah'})).json,
             {'test': 'yeah'})
@@ -77,10 +77,10 @@ class TestResource(TestCase):
         self.app.head("/users", status=200)
         self.app.head("/users/1", status=200)
 
-        self.assertEquals(
+        self.assertEqual(
             self.patch("/users", status=200).json,
             {'test': 'yeah'})
 
-        self.assertEquals(
+        self.assertEqual(
             self.patch("/users/1", status=200).json,
             {'test': 'yeah'})

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -70,8 +70,8 @@ if COLANDER:
             body_fields = schema.get_attributes(location="body")
             qs_fields = schema.get_attributes(location="querystring")
 
-            self.assertEquals(len(body_fields), 2)
-            self.assertEquals(len(qs_fields), 1)
+            self.assertEqual(len(body_fields), 2)
+            self.assertEqual(len(qs_fields), 1)
 
         def test_colander_integration_with_header(self):
             schema = CorniceSchema.from_colander(TestingSchemaWithHeader)
@@ -80,10 +80,10 @@ if COLANDER:
             qs_fields = schema.get_attributes(location="querystring")
             header_fields = schema.get_attributes(location="header")
 
-            self.assertEquals(len(all_fields), 4)
-            self.assertEquals(len(body_fields), 2)
-            self.assertEquals(len(qs_fields), 1)
-            self.assertEquals(len(header_fields), 1)
+            self.assertEqual(len(all_fields), 4)
+            self.assertEqual(len(body_fields), 2)
+            self.assertEqual(len(qs_fields), 1)
+            self.assertEqual(len(header_fields), 1)
 
         def test_colander_inheritance(self):
             """
@@ -96,7 +96,7 @@ if COLANDER:
             base_schema = CorniceSchema.from_colander(TestingSchema)
             inherited_schema = CorniceSchema.from_colander(InheritedSchema)
 
-            self.assertEquals(len(base_schema.get_attributes()),
+            self.assertEqual(len(base_schema.get_attributes()),
                               len(inherited_schema.get_attributes()))
 
             foo_filter = lambda x: x.name == "foo"
@@ -123,5 +123,5 @@ if COLANDER:
             body_fields = schema.get_attributes(location="body")
             qs_fields = schema.get_attributes(location="querystring")
 
-            self.assertEquals(len(body_fields), 2)
-            self.assertEquals(len(qs_fields), 1)
+            self.assertEqual(len(body_fields), 2)
+            self.assertEqual(len(qs_fields), 1)

--- a/cornice/tests/test_service.py
+++ b/cornice/tests/test_service.py
@@ -17,58 +17,58 @@ class TestService(TestCase):
 
     def test_service_instanciation(self):
         service = Service("coconuts", "/migrate")
-        self.assertEquals(service.name, "coconuts")
-        self.assertEquals(service.path, "/migrate")
-        self.assertEquals(service.renderer, Service.renderer)
+        self.assertEqual(service.name, "coconuts")
+        self.assertEqual(service.path, "/migrate")
+        self.assertEqual(service.renderer, Service.renderer)
 
         service = Service("coconuts", "/migrate", renderer="html")
-        self.assertEquals(service.renderer, "html")
+        self.assertEqual(service.renderer, "html")
 
         # test that lists are also set
         validators = [lambda x: True, ]
         service = Service("coconuts", "/migrate", validators=validators)
-        self.assertEquals(service.validators, validators)
+        self.assertEqual(service.validators, validators)
 
     def test_get_arguments(self):
         service = Service("coconuts", "/migrate")
         # not specifying anything, we should get the default values
         args = service.get_arguments({})
         for arg in Service.mandatory_arguments:
-            self.assertEquals(args[arg], getattr(Service, arg, None))
+            self.assertEqual(args[arg], getattr(Service, arg, None))
 
         # calling this method on a configured service should use the values
         # passed at instanciation time as default values
         service = Service("coconuts", "/migrate", renderer="html")
         args = service.get_arguments({})
-        self.assertEquals(args['renderer'], 'html')
+        self.assertEqual(args['renderer'], 'html')
 
         # if we specify another renderer for this service, despite the fact
         # that one is already set in the instance, this one should be used
         args = service.get_arguments({'renderer': 'foobar'})
-        self.assertEquals(args['renderer'], 'foobar')
+        self.assertEqual(args['renderer'], 'foobar')
 
         # test that list elements are not overwritten
         # define a validator for the needs of the test
 
         service = Service("vaches", "/fetchez", validators=(_validator,))
-        self.assertEquals(len(service.validators), 1)
+        self.assertEqual(len(service.validators), 1)
         args = service.get_arguments({'validators': (_validator2,)})
 
         # the list of validators didn't changed
-        self.assertEquals(len(service.validators), 1)
+        self.assertEqual(len(service.validators), 1)
 
         # but the one returned contains 2 validators
-        self.assertEquals(len(args['validators']), 2)
+        self.assertEqual(len(args['validators']), 2)
 
         # test that exclude effectively removes the items from the list of
         # validators / filters it returns, without removing it from the ones
         # registered for the service.
         service = Service("open bar", "/bar", validators=(_validator,
                                                           _validator2))
-        self.assertEquals(service.validators, [_validator, _validator2])
+        self.assertEqual(service.validators, [_validator, _validator2])
 
         args = service.get_arguments({"exclude": _validator2})
-        self.assertEquals(args['validators'], [_validator])
+        self.assertEqual(args['validators'], [_validator])
 
         # defining some non-mandatory arguments in a service should make
         # them available on further calls to get_arguments.
@@ -85,12 +85,12 @@ class TestService(TestCase):
         def view(request):
             pass
         service.add_view("post", view, validators=(_validator,))
-        self.assertEquals(len(service.definitions), 1)
+        self.assertEqual(len(service.definitions), 1)
         method, _view, _ = service.definitions[0]
 
         # the view had been registered. we also test here that the method had
         # been inserted capitalized (POST instead of post)
-        self.assertEquals(("POST", view), (method, _view))
+        self.assertEqual(("POST", view), (method, _view))
 
     def test_decorators(self):
         service = Service("color", "/favorite-color")
@@ -99,11 +99,11 @@ class TestService(TestCase):
         def get_favorite_color(request):
             return "blue, hmm, red, hmm, aaaaaaaah"
 
-        self.assertEquals(2, len(service.definitions))
+        self.assertEqual(2, len(service.definitions))
         method, view, _ = service.definitions[0]
-        self.assertEquals(("GET", get_favorite_color), (method, view))
+        self.assertEqual(("GET", get_favorite_color), (method, view))
         method, view, _ = service.definitions[1]
-        self.assertEquals(("HEAD", get_favorite_color), (method, view))
+        self.assertEqual(("HEAD", get_favorite_color), (method, view))
 
         @service.post(accept='text/plain', renderer='plain')
         @service.post(accept='application/json')
@@ -112,41 +112,41 @@ class TestService(TestCase):
 
         # using multiple decorators on a resource should register them all in
         # as many different definitions in the service
-        self.assertEquals(4, len(service.definitions))
+        self.assertEqual(4, len(service.definitions))
 
         @service.patch()
         def patch_favorite_color(request):
             return ""
 
         method, view, _ = service.definitions[4]
-        self.assertEquals("PATCH", method)
+        self.assertEqual("PATCH", method)
 
     def test_get_acceptable(self):
         # defining a service with different "accept" headers, we should be able
         # to retrieve this information easily
         service = Service("color", "/favorite-color")
         service.add_view("GET", lambda x: "blue", accept="text/plain")
-        self.assertEquals(service.get_acceptable("GET"), ['text/plain'])
+        self.assertEqual(service.get_acceptable("GET"), ['text/plain'])
 
         service.add_view("GET", lambda x: "blue", accept="application/json")
-        self.assertEquals(service.get_acceptable("GET"),
+        self.assertEqual(service.get_acceptable("GET"),
                           ['text/plain', 'application/json'])
 
         # adding a view for the POST method should not break everything :-)
         service.add_view("POST", lambda x: "ok", accept=('foo/bar'))
-        self.assertEquals(service.get_acceptable("GET"),
+        self.assertEqual(service.get_acceptable("GET"),
                           ['text/plain', 'application/json'])
         # and of course the list of accepted content-types  should be available
         # for the "POST" as well.
-        self.assertEquals(service.get_acceptable("POST"),
+        self.assertEqual(service.get_acceptable("POST"),
                           ['foo/bar'])
 
         # it is possible to give acceptable content-types dynamically at
         # run-time. You don't always want to have the callables when retrieving
         # all the acceptable content-types
         service.add_view("POST", lambda x: "ok", accept=lambda r: "text/json")
-        self.assertEquals(len(service.get_acceptable("POST")), 2)
-        self.assertEquals(len(service.get_acceptable("POST", True)), 1)
+        self.assertEqual(len(service.get_acceptable("POST")), 2)
+        self.assertEqual(len(service.get_acceptable("POST", True)), 1)
 
     def test_get_validators(self):
         # defining different validators for the same services, even with
@@ -164,7 +164,7 @@ class TestService(TestCase):
         service.add_view('GET', lambda x: 'ok',
                          validators=(validator, validator))
         service.add_view('GET', lambda x: 'ok', validators=(validator2))
-        self.assertEquals(service.get_validators('GET'),
+        self.assertEqual(service.get_validators('GET'),
                           [validator, validator2])
 
     if validationapp.COLANDER:
@@ -172,10 +172,10 @@ class TestService(TestCase):
             schema = validationapp.FooBarSchema
             service = Service("color", "/favorite-color")
             service.add_view("GET", lambda x: "red", schema=schema)
-            self.assertEquals(len(service.schemas_for("GET")), 1)
+            self.assertEqual(len(service.schemas_for("GET")), 1)
             service.add_view("GET", lambda x: "red", validators=_validator,
                              schema=schema)
-            self.assertEquals(len(service.schemas_for("GET")), 2)
+            self.assertEqual(len(service.schemas_for("GET")), 2)
 
     def test_class_parameters(self):
         # when passing a "klass" argument, it gets registered. It also tests
@@ -187,23 +187,23 @@ class TestService(TestCase):
                           klass=TemperatureCooler)
         service.add_view("get", "get_fresh_air")
 
-        self.assertEquals(len(service.definitions), 2)
+        self.assertEqual(len(service.definitions), 2)
 
         method, view, args = service.definitions[0]
-        self.assertEquals(view, "get_fresh_air")
-        self.assertEquals(args["klass"], TemperatureCooler)
+        self.assertEqual(view, "get_fresh_air")
+        self.assertEqual(args["klass"], TemperatureCooler)
 
     def test_get_services(self):
-        self.assertEquals([], get_services())
+        self.assertEqual([], get_services())
         foobar = Service("Foobar", "/foobar")
         self.assertIn(foobar, get_services())
 
         barbaz = Service("Barbaz", "/barbaz")
         self.assertIn(barbaz, get_services())
 
-        self.assertEquals([barbaz, ], get_services(exclude=['Foobar', ]))
-        self.assertEquals([foobar, ], get_services(names=['Foobar', ]))
-        self.assertEquals([foobar, barbaz],
+        self.assertEqual([barbaz, ], get_services(exclude=['Foobar', ]))
+        self.assertEqual([foobar, ], get_services(names=['Foobar', ]))
+        self.assertEqual([foobar, barbaz],
                           get_services(names=['Foobar', 'Barbaz']))
 
     def test_default_validators(self):
@@ -304,7 +304,7 @@ class TestService(TestCase):
         # check that adding the same header twice doesn't make bad things
         # happen
         service.add_view('POST', _stub, cors_headers=('X-Header-Foobar'),)
-        self.assertEquals(len(service.cors_supported_headers), 2)
+        self.assertEqual(len(service.cors_supported_headers), 2)
 
         # check that adding a header on a cors disabled method doesn't
         # change anything
@@ -375,7 +375,7 @@ class TestService(TestCase):
 
     def test_max_age_can_be_defined(self):
         foo = Service(name='foo', path='/foo', cors_max_age=42)
-        self.assertEquals(foo.cors_max_age_for(), 42)
+        self.assertEqual(foo.cors_max_age_for(), 42)
 
     def test_max_age_can_be_different_dependeing_methods(self):
         foo = Service(name='foo', path='/foo', cors_max_age=42)
@@ -383,9 +383,9 @@ class TestService(TestCase):
         foo.add_view('POST', _stub, cors_max_age=32)
         foo.add_view('PUT', _stub, cors_max_age=7)
 
-        self.assertEquals(foo.cors_max_age_for('GET'), 42)
-        self.assertEquals(foo.cors_max_age_for('POST'), 32)
-        self.assertEquals(foo.cors_max_age_for('PUT'), 7)
+        self.assertEqual(foo.cors_max_age_for('GET'), 42)
+        self.assertEqual(foo.cors_max_age_for('POST'), 32)
+        self.assertEqual(foo.cors_max_age_for('PUT'), 7)
 
     def test_cors_policy(self):
         policy = {'origins': ('foo', 'bar', 'baz')}
@@ -398,4 +398,4 @@ class TestService(TestCase):
         policy = {'origins': ('foo', 'bar', 'baz')}
         foo = Service(name='foo', path='/foo', cors_origins=(),
                       cors_policy=policy)
-        self.assertEquals(len(foo.cors_supported_origins), 0)
+        self.assertEqual(len(foo.cors_supported_origins), 0)

--- a/cornice/tests/test_service_definition.py
+++ b/cornice/tests/test_service_definition.py
@@ -43,11 +43,11 @@ class TestServiceDefinition(TestCase):
     def test_basic_service_operation(self):
 
         self.app.get("/unknown", status=404)
-        self.assertEquals(
+        self.assertEqual(
             self.app.get("/service1").json,
             {'test': "succeeded"})
 
-        self.assertEquals(
+        self.assertEqual(
             self.app.post("/service1", params="BODY").json,
             {'body': 'BODY'})
 
@@ -73,7 +73,7 @@ class TestServiceDefinition(TestCase):
         # Stacking multiple @api calls on a single function should
         # register it multiple times, just like @view_config does.
         resp = self.app.get("/service2", headers={'Accept': 'text/html'})
-        self.assertEquals(resp.json, {'test': 'succeeded'})
+        self.assertEqual(resp.json, {'test': 'succeeded'})
 
         resp = self.app.post("/service2", headers={'Accept': 'audio/ogg'})
-        self.assertEquals(resp.json, {'test': 'succeeded'})
+        self.assertEqual(resp.json, {'test': 'succeeded'})

--- a/cornice/tests/test_validation.py
+++ b/cornice/tests/test_validation.py
@@ -58,30 +58,30 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
 
         # requesting a supported type should give an appropriate response type
         r = app.get('/service2', headers={'Accept': 'application/*'})
-        self.assertEquals(r.content_type, "application/json")
+        self.assertEqual(r.content_type, "application/json")
 
         r = app.get('/service2', headers={'Accept': 'text/plain'})
-        self.assertEquals(r.content_type, "text/plain")
+        self.assertEqual(r.content_type, "text/plain")
 
         # it should also work with multiple Accept headers
         r = app.get('/service2', headers={'Accept': 'audio/*, application/*'})
-        self.assertEquals(r.content_type, "application/json")
+        self.assertEqual(r.content_type, "application/json")
 
         # and requested preference order should be respected
         r = app.get('/service2',
                     headers={'Accept': 'application/json; q=1.0, text/plain; q=0.9'})
-        self.assertEquals(r.content_type, "application/json")
+        self.assertEqual(r.content_type, "application/json")
 
         r = app.get('/service2',
                     headers={'Accept': 'text/plain; q=0.9, application/json; q=1.0'})
-        self.assertEquals(r.content_type, "application/json")
+        self.assertEqual(r.content_type, "application/json")
 
         # test that using a callable to define what's accepted works as well
         res = app.get('/service3', headers={'Accept': 'audio/*'}, status=406)
         self.assertTrue('text/json' in res.json)
 
         res = app.get('/service3', headers={'Accept': 'text/*'}, status=200)
-        self.assertEquals(res.content_type, "text/json")
+        self.assertEqual(res.content_type, "text/json")
 
         # if we are not asking for a particular content-type,
         # we should get one of the two types that the service supports.
@@ -92,19 +92,19 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         app = TestApp(main({}))
 
         res = app.get('/service3', headers={'Accept': 'text/*'}, status=200)
-        self.assertEquals(res.content_type, "text/json")
+        self.assertEqual(res.content_type, "text/json")
 
     def test_accept_issue_113_text_application_star(self):
         app = TestApp(main({}))
 
         res = app.get('/service3', headers={'Accept': 'application/*'}, status=200)
-        self.assertEquals(res.content_type, "application/json")
+        self.assertEqual(res.content_type, "application/json")
 
     def test_accept_issue_113_text_application_json(self):
         app = TestApp(main({}))
 
         res = app.get('/service3', headers={'Accept': 'application/json'}, status=200)
-        self.assertEquals(res.content_type, "application/json")
+        self.assertEqual(res.content_type, "application/json")
 
     def test_accept_issue_113_text_html_not_acceptable(self):
         app = TestApp(main({}))
@@ -116,7 +116,7 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         app = TestApp(main({}))
 
         res = app.get('/service2', headers={'Accept': 'audio/mp4; q=0.9, text/plain; q=0.5'}, status=200)
-        self.assertEquals(res.content_type, "text/plain")
+        self.assertEqual(res.content_type, "text/plain")
 
         # if we are not asking for a particular content-type,
         # we should get one of the two types that the service supports.


### PR DESCRIPTION
When running tests under Py3k, these deprecation warnings appear:

```
DeprecationWarning: Please use assertEqual instead.
```

This PR accounts for that.
