### PR TITLE
Fix CORS support for the request headers.

### DIFF
--- a/cornice/cors.py
+++ b/cornice/cors.py
@@ -36,7 +36,7 @@ def get_cors_preflight_view(service):
             request.headers.get('Access-Control-Request-Headers', ()))
 
         if requested_headers:
-            requested_headers = requested_headers.split(',')
+            requested_headers = map(str.strip, requested_headers.split(', '))
 
         if requested_method not in service.cors_supported_methods:
             request.errors.add('header', 'Access-Control-Request-Method',

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -195,7 +195,9 @@ class TestCORS(TestCase):
         resp = self.app.options('/squirel',
             headers={'Origin': 'notmyidea.org',
                      'Access-Control-Request-Method': 'GET',
-                     'Access-Control-Request-Headers': 'foo,bar,baz'})
+                     'Access-Control-Request-Headers': 'foo,    bar,baz  '})
+        # The specification says we can have any number of LWS (Linear white
+        # spaces) in the values and that it should be removed.
 
         # per default, they should be authorized, and returned in the list of
         # authorized headers


### PR DESCRIPTION
Access-Control-Request-Headers fields can contain any number of spaces, this wasn't done properly until now.

The specification of field-names say (http://tools.ietf.org/html/rfc2616#section-4.2)

   message-header = field-name ":" [ field-value ]
   field-name     = token
   field-value    = *( field-content | LWS )
   field-content  = <the OCTETs making up the field-value
                    and consisting of either *TEXT or combinations
                    of token, separators, and quoted-string>
