### PR TITLE
make nosetest after buildout work

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,6 +6,6 @@ develop = .
 [eggs]
 recipe = z3c.recipe.scripts
 eggs =
-    cornice
+    cornice [test]
     nose
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,6 @@ setup(name='cornice',
       zip_safe=False,
       install_requires=requires,
       tests_require=test_requires,
+      extras_require={'test': test_requires},
       test_suite="cornice.tests",
       paster_plugins=['pyramid'])


### PR DESCRIPTION
When doing `bin/buildout` and then `bin/nosetest`, the tests would produce errors, since the tests_require packages are not installed by buildout.

This patch fixes this by adding and using an `extras_requires` named test.
