### PR TITLE
Validator.py should not assume response has content_type attribute

### DIFF
--- a/cornice/validators.py
+++ b/cornice/validators.py
@@ -10,7 +10,7 @@ safe_json_re = re.compile(r'\s*[\{tfn\-0-9]'.encode('ascii'), re.MULTILINE)
 def filter_json_xsrf(response):
     """drops a warning if a service returns potentially exploitable json
     """
-    if response.content_type in ('application/json', 'text/json'):
+    if hasattr(response, 'content_type') and response.content_type in ('application/json', 'text/json'):
         if safe_json_re.match(response.body) is None:
             from cornice import logger
             logger.warn("returning a json string or array is a potential "


### PR DESCRIPTION
## Description

If the content_type attribute of a response is set to None in a view, the resulting response will not have the 'content_type' attribute. This results in an error in cornice's validator where it assumes 'content_type' will always be an attriubte of the passed in response object. I do not know why Pyramid does this, but it does it. The example below responds to a delete request with a 204 with no content and no content_type (a successful delete).
### Example:

``` python

@resource(collection_path='/resource/', path='/resource/{id}')
class ActionView:

  def __init__(self, request):
    self.request = request

  def delete(self):
     # do some stuff
    self.request.response.content_type = None
    self.request.response.status_code = 204
    return 
```

When delete is called, cornice errors :

``` bash
  File "/xxxxx/eggs/cornice-0.14-py3.3.egg/cornice/validators.py", line 13, in filter_json_xsrf
    if response.content_type in ('application/json', 'text/json'):
nose.proxy.AttributeError: 'AttributeError' object has no attribute 'content_type'
```
### Versions

pyramid: 1.4.3
cornice: 0.14
## Testing Notes

I tried running the tests before creating this pull request, but I had to do a bit of work to get it to work using python 3.3. After changing some files to get buildout to work with Python 3.3, I ran the tests (nosetests inside cornice directory) and got errors:

``` bash
  File "/home/gewthen/dev/cornice/cornice/schemas.py", line 79, in validate_colander_schema
    from colander import Invalid, Sequence, drop
ImportError: cannot import name drop
```
