### PR TITLE
Added venusion depth support to cornice.resource

### DIFF
--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -10,7 +10,7 @@ except ImportError:
     VENUSIAN = False
 
 
-def resource(**kw):
+def resource(depth=1, **kw):
     """Class decorator to declare resources.
 
     All the methods of this class named by the name of HTTP resources
@@ -77,7 +77,7 @@ def resource(**kw):
                     config = context.config.with_package(info.module)
                     config.add_cornice_service(service)
 
-            info = venusian.attach(klass, callback, category='pyramid')
+            info = venusian.attach(klass, callback, category='pyramid', depth=depth)
         return klass
     return wrapper
 


### PR DESCRIPTION
This allows you more versatility in how you decorate your services with
the resource class. One particular use case is when you want to
dynamically build your resource parameters, you need to decorate the
resource decorator in order to generate the parameters. Basically, you
are introspecting the routing information from the service itself.

```
# Something like this:
@resource(
    path= '/user/{id}',
    collection_path='/user',
    accept=['text/xml', 'text/json'])
class User(BaseService):

# becomes something like this:
def myresource(service_class):
    # inject the depth parameter into the parameters to offset
    # venusian's expected scope
    params = dict(service_class.get_route_params(), depth=2)
    return resource(**params)(service_class)

@myservice
class User(BaseService):
```

Implementation is similar to how cornice.service handles venusion
support.  This is needed because cornice uses the venusian module to
delegate decoration, and venusion makes assumptions about your code for
decoration eligibility. That assumption can be described as:

```
“The target of decoration must be defined in the same scope that the
```

decoration is applied in order for the decoration to be eligible for
application.”

Venusian introspects the module from which the decorated entity is
defined.  If the the decorated entity was defined in a module other than
the module that decorator was applied, it assumes that the entity was
imported into that module and should not be decorated.

Venusion supports a decorator depth offset, which allows you to adjust
the scope of where venusion believes the decoration was applied at.
This change provides support for passing the depth parameter through the
cornice.resource decorator to venusion.
