### PR TITLE
Add slightly more expressive error.

### DIFF
--- a/cornice/util.py
+++ b/cornice/util.py
@@ -93,7 +93,8 @@ def extract_request_data(request):
         try:
             body = json.loads(request.body)
         except ValueError as e:
-            request.errors.add('body', None, e.message)
+            request.errors.add('body', None,
+                               "Invalid JSON request body: %s" % (e.message))
             body = {}
     else:
         body = {}


### PR DESCRIPTION
It isn't documented thoroughly that Cornice only deals with JSON requests.

Actually, it could quite simply support standard www-form, with the flattened convention from Colander, couldn't it ?

Anyway, I was debugging and it took a while to figure out it was
trying to decode my www-form into JSON.  This makes it a little more explicit.
