### PR TITLE
Check uniqueness of the service name

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -194,6 +194,13 @@ class Service(object):
         # this service.
         self.defined_methods = []
         self.definitions = []
+        
+        # check if there is another service registered with the same name
+        for service in SERVICES:
+            if service.name == self.name:
+                msg = "There is already service registered with this name: %s"\
+                      % self.name
+                raise Exception(msg)
 
         # add this service to the list of available services
         SERVICES.append(self)


### PR DESCRIPTION
While maintaining two or more APIs in one Pyramid project is easy to pass same name to two different Services. Cornice will not tell you that something is wrong and will connect path from second service to the first one which may be confusing. According to documentation from services.Service name should be unique and this few lines of code assures that.
