### PR TITLE
Reuse the request.context

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -481,7 +481,7 @@ def decorate_view(view, args, method):
         if 'klass' in args and not callable(view):
             params = dict(request=request)
             if 'factory' in args and 'acl' not in args:
-                params['context'] = args['factory'](request)
+                params['context'] = request.context
             ob = args['klass'](**params)
             if is_string(view):
                 view_ = getattr(ob, view.lower())

--- a/cornice/tests/support.py
+++ b/cornice/tests/support.py
@@ -14,6 +14,7 @@ except ImportError:
 from webob.dec import wsgify
 from webob import exc
 from pyramid.httpexceptions import HTTPException
+from pyramid import testing
 
 
 logger = logging.getLogger('cornice')
@@ -23,6 +24,13 @@ class DummyContext(object):
 
     def __repr__(self):
         return 'context!'
+
+
+class DummyRequest(testing.DummyRequest):
+    errors = []
+    def __init__(self, *args, **kwargs):
+        super(DummyRequest, self).__init__(*args, **kwargs)
+        self.context = DummyContext()
 
 
 def dummy_factory(request):


### PR DESCRIPTION
Cornice service accept a "factory" parameter and pass it to the view.
The factory build an object in the pyramid framework, so, cornice
did not need to build it again.
Furthermore, by this change, factory can now be a string exactly
like in pyramid.
