### PR TITLE
#229, does not cooperate with ZCA registry, fixed

### DIFF
--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -100,7 +100,7 @@ def get_fallback_view(service):
 def apply_filters(request, response):
     if request.matched_route is not None:
         # do some sanity checking on the response using filters
-        services = request.registry.get('cornice_services', {})
+        services = _getattr(request.registry, 'cornice_services', {})
         pattern = request.matched_route.pattern
         service = services.get(pattern, None)
         if service is not None:
@@ -150,7 +150,7 @@ def register_service_views(config, service):
     :param config: the pyramid configuration object that will be populated.
     :param service: the service object containing the definitions
     """
-    services = config.registry.setdefault('cornice_services', {})
+    services = _getattr(config.registry, 'cornice_services', {})
     prefix = config.route_prefix or ''
     services[prefix + service.path] = service
 
@@ -323,3 +323,9 @@ def add_deserializer(config, content_type, deserializer):
         registry.cornice_deserializers[content_type] = deserializer
 
     config.action(content_type, callable=callback)
+
+
+def _getattr(obj, name, default):
+    if not hasattr(obj, name):
+        setattr(obj, name, default)
+    return getattr(obj, name)

--- a/cornice/tests/test_pyramidhook.py
+++ b/cornice/tests/test_pyramidhook.py
@@ -146,7 +146,7 @@ class TestRouteWithTraverse(TestCase):
         config.add_directive('add_cornice_service', register_service_views)
         config.scan("cornice.tests.test_pyramidhook")
 
-        services = config.registry.get('cornice_services', {})
+        services = getattr(config.registry, 'cornice_services', {})
         self.assertTrue('/prefix/wrapperservice' in services)
 
 


### PR DESCRIPTION
```
ZCA's registry does not behave like a dict. Cornice specific data
should be attached as attributes to the 'registry' instead of
key-values.
```
