### PR TITLE
#229, does not cooperate with ZCA registry, fixed

### DIFF
--- a/cornice/__init__.py
+++ b/cornice/__init__.py
@@ -37,6 +37,9 @@ def includeme(config):
     """
     from pyramid.events import BeforeRender, NewRequest
 
+    # attributes required to maintain services
+    config.registry.cornice_services = {}
+
     #config.add_directive('add_apidoc', add_apidoc)
     config.add_directive('add_cornice_service', register_service_views)
     config.add_directive('add_cornice_deserializer', add_deserializer)

--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -100,7 +100,7 @@ def get_fallback_view(service):
 def apply_filters(request, response):
     if request.matched_route is not None:
         # do some sanity checking on the response using filters
-        services = request.registry.get('cornice_services', {})
+        services = request.registry.cornice_services
         pattern = request.matched_route.pattern
         service = services.get(pattern, None)
         if service is not None:
@@ -150,7 +150,7 @@ def register_service_views(config, service):
     :param config: the pyramid configuration object that will be populated.
     :param service: the service object containing the definitions
     """
-    services = config.registry.setdefault('cornice_services', {})
+    services = config.registry.cornice_services
     prefix = config.route_prefix or ''
     services[prefix + service.path] = service
 

--- a/cornice/tests/test_pyramidhook.py
+++ b/cornice/tests/test_pyramidhook.py
@@ -143,10 +143,11 @@ class TestRouteWithTraverse(TestCase):
         config = testing.setUp(settings={})
         config.add_route = MagicMock()
         config.route_prefix = '/prefix'
+        config.registry.cornice_services = {}
         config.add_directive('add_cornice_service', register_service_views)
         config.scan("cornice.tests.test_pyramidhook")
 
-        services = config.registry.get('cornice_services', {})
+        services = config.registry.cornice_services
         self.assertTrue('/prefix/wrapperservice' in services)
 
 
@@ -158,6 +159,7 @@ class NonpickableSchema(colander.Schema):
 class TestServiceWithNonpickleableSchema(TestCase):
     def setUp(self):
         self.config = testing.setUp()
+        self.config.registry.cornice_services = {}
 
     def tearDown(self):
         testing.tearDown()


### PR DESCRIPTION
```
ZCA's registry does not behave like a dict. Cornice specific data
should be attached as attributes to the 'registry' instead of
key-values.
```
