### PR TITLE
Enabling colander custom schema validators

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -111,3 +111,14 @@ def validate_colander_schema(schema, request):
     _validate_fields('header', headers)
     _validate_fields('body', body)
     _validate_fields('querystring', qs)
+
+    c_schema = schema._c_schema
+
+    from colander import deferred
+    if c_schema.validator is not None:
+        if not isinstance(c_schema.validator, deferred): # unbound
+            try:
+                c_schema.validator(c_schema, request.validated)
+            except Invalid as e:
+                # the struct is invalid
+                request.errors.add('', 'custom validators', e.asdict()[''])


### PR DESCRIPTION
If you have a validator function on your colander MappingSchema subclass, this patch will run the validator function and add errors as necessary. Heavily borrows from https://github.com/mozilla-services/cornice/pull/193.
