### PR TITLE
Semi-colon terminated jsonp in the tests.

### DIFF
--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -68,7 +68,7 @@ class TestResource(TestCase):
         self.assertEqual(self.app.get("/users/1").json, {'name': 'gawel'})
 
         resp = self.app.get("/users/1?callback=test")
-        self.assertEqual(resp.body, b'test({"name": "gawel"});')
+        self.assertEqual(resp.body, b'test({"name": "gawel"});', resp.body)
 
     def test_accept_headers(self):
         # the accept headers should work even in case they're specified in a


### PR DESCRIPTION
I'm not sure why, but this test was failing when I first cloned the repo.

It seems harmless to have a semicolon at the end of a jsonp response, so, why
not?

Feel free to reject if you know better.
