### PR TITLE
Support "flattened" post data

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
+import webob.multidict
 from cornice.util import to_list, extract_request_data
 
 
@@ -65,6 +66,12 @@ class CorniceSchema(object):
 
         return schema
 
+    def unflatten(self, data):
+        return self._c_schema.unflatten(data)
+
+    def flatten(self, data):
+        return self._c_schema.flatten(data)
+
     @classmethod
     def from_colander(klass, colander_schema):
         return CorniceSchema(colander_schema)
@@ -75,6 +82,14 @@ def validate_colander_schema(schema, request):
     from colander import Invalid, Sequence, drop
 
     def _validate_fields(location, data):
+        if location == 'body':
+            try:
+                original = data
+                data = webob.multidict.MultiDict(schema.unflatten(data))
+                data.update(original)
+            except KeyError:
+                pass
+
         for attr in schema.get_attributes(location=location,
                                           request=request):
             if attr.required and not attr.name in data:

--- a/cornice/tests/test_service_description.py
+++ b/cornice/tests/test_service_description.py
@@ -194,6 +194,14 @@ if COLANDER:
             self.app.post_json('/nested', params=nested_data,
                                status=400)
 
+        def test_nested_schemas_with_flattened_values(self):
+
+            data = {"title": "Mushroom",
+                    "fields.0.name": "genre",
+                    "fields.0.description": "Genre"}
+
+            resp = self.app.post('/nested', params=data, status=200)
+
         def test_qux_header(self):
             resp = self.app.delete('/foobar', status=400)
             self.assertEqual(resp.json, {


### PR DESCRIPTION
The comment for commit 2847c997166693e77bbb6dd016c329fd04b72f60 mentions
potential support for flattened post data using colander's conventions.  This
commit:
- Attempts to unflatten the payloads of incoming requests
- Adds a hitherto failing test for "flattened" post data.
