### PR TITLE
Add missing file to the MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.txt
 include *.rst
 include LICENSE
 recursive-include cornice/scaffolds *.*
+recursive-include cornice/tests *.rx


### PR DESCRIPTION
Tests fail when run from a tarball without this.
