### PR TITLE
fixed broken validation with extra params in querystring

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -101,8 +101,11 @@ def validate_colander_schema(schema, request):
                 pass
 
         if location == 'querystring':
-            original = data
-            data = schema.unflatten(original)
+            try:
+                original = data
+                data = schema.unflatten(original)
+            except KeyError:
+                pass
 
         for attr in schema.get_attributes(location=location,
                                           request=request):


### PR DESCRIPTION
If extra (unknown) parameters are passed in querystring, `colander_schema.unflatten(data)` raises KeyError exc. Validation should just swallow the exception, the error is handled later.
