### PR TITLE
cornice.ext.sphinxext Python 3 compatibility fix

### DIFF
--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -66,7 +66,7 @@ class ServiceDirective(Directive):
 
         # import the modules, which will populate the SERVICES variable.
         for module in self.options.get('modules'):
-            if MODULES.has_key(module):
+            if module in MODULES:
                 reload(MODULES[module])
             else:
                 MODULES[module] = import_module(module)


### PR DESCRIPTION
Fixed cornice.ext.sphinxext to be compatible with Python 3 - replaced "dict.has_key(x)" with "x in dict".
