### PR TITLE
Set permission for fallback view to NO_PERMISSION_REQUIRED

### DIFF
--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -8,6 +8,7 @@ import itertools
 from pyramid.httpexceptions import (HTTPMethodNotAllowed, HTTPNotAcceptable,
                                     HTTPUnsupportedMediaType, HTTPException)
 from pyramid.exceptions import PredicateMismatch
+from pyramid.security import NO_PERMISSION_REQUIRED
 
 from cornice.service import decorate_view
 from cornice.errors import Errors
@@ -207,7 +208,8 @@ def register_service_views(config, service):
         if service.path not in registered_routes:
             config.add_route(service.name, service.path, **route_args)
             config.add_view(view=get_fallback_view(service),
-                            route_name=service.name)
+                            route_name=service.name,
+                            permission=NO_PERMISSION_REQUIRED)
             registered_routes.append(service.path)
             config.commit()
 


### PR DESCRIPTION
If a default permission is set for all views, the fallback view will
fail with a 403 Unauthorized. Invalid Method, Accept, or Content-Type
predicate mismatches will not produce the correct status and error
messages.

Fixes: https://github.com/mozilla-services/cornice/issues/245
