### PR TITLE
Avoid TypeError

### DIFF
--- a/docs/source/spore.rst
+++ b/docs/source/spore.rst
@@ -12,7 +12,7 @@ Here is how you can let cornice describe your web service for you::
     from cornice.service import Service, get_services
 
     spore = Service('spore', path='/spore', renderer='jsonp')
-    @spore.get
+    @spore.get()
     def get_spore(request):
         services = get_services()
         return generate_spore_description(services, 'Service name', request.application_url, '1.0')


### PR DESCRIPTION
TypeError: decorator() takes exactly 2 arguments (3 given)
