### PR TITLE
Fix warnings for the cors preflight view

### DIFF
--- a/cornice/cors.py
+++ b/cornice/cors.py
@@ -65,7 +65,7 @@ def get_cors_preflight_view(service):
         if max_age is not None:
             response.headers['Access-Control-Max-Age'] = str(max_age)
 
-        return ''
+        return {}
     return _preflight_view
 
 


### PR DESCRIPTION
The default cors preflight view always returns an empty string which is serialised to a quoted empty string. The regular expression at https://github.com/mozilla-services/cornice/blob/master/cornice/validators.py#L7 does not evaluate true for this case. Returning an empty object eliminates the xsrf warnings generated by the default filter.
