### PR TITLE
Let user override default acceptable content_type's

### DIFF
--- a/cornice/tests/test_validation.py
+++ b/cornice/tests/test_validation.py
@@ -140,6 +140,19 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         self.assertTrue(response.content_type
                         in ("application/json", "text/plain"))
 
+    def test_override_default_accept_issue_252(self):
+        # override default acceptable content_types for interoperate with
+        # legacy applications i.e. ExtJS 3
+        from cornice.util import _JsonRenderer
+        _JsonRenderer.acceptable += ('text/html',)
+
+        app = TestApp(main({}))
+
+        response = app.get('/service5', headers={'Accept': 'text/html'})
+        self.assertEqual(response.content_type, "text/html")
+        # revert the override
+        _JsonRenderer.acceptable = _JsonRenderer.acceptable[:-1]
+
     def test_filters(self):
         app = TestApp(main({}))
 

--- a/cornice/util.py
+++ b/cornice/util.py
@@ -41,6 +41,8 @@ class _JsonRenderer(object):
       .. _`[1]`: https://github.com/mozilla-services/cornice/pull/116#issuecomment-14355865
       .. _`[2]`: http://pyramid.readthedocs.org/en/latest/narr/renderers.html#serializing-custom-objects
     """
+    acceptable = ('application/json', 'text/json', 'text/plain')
+
     def __call__(self, data, context):
         """Serialise the ``data`` with the Pyramid renderer."""
         # Unpack the context.
@@ -68,8 +70,7 @@ class _JsonRenderer(object):
         json_str = renderer(data, context)
 
         # XXX So we (re)set it ourselves here, i.e.: *after* the previous call.
-        acceptable = ('application/json', 'text/json', 'text/plain')
-        content_type = (request.accept.best_match(acceptable) or acceptable[0])
+        content_type = (request.accept.best_match(self.acceptable) or self.acceptable[0])
         response.content_type = content_type
         return json_str
 


### PR DESCRIPTION
Provides a path for working around #252 and interoperate with ExtJS 3 that imposes json content-type to be 'text/html'.
