### PR TITLE
Fix CORS implementation with credentials.

### DIFF
--- a/cornice/cors.py
+++ b/cornice/cors.py
@@ -96,6 +96,8 @@ def ensure_origin(service, request, response=None):
                         for o in service.cors_origins_for(method)]):
                 request.errors.add('header', 'Origin',
                                    '%s not allowed' % origin)
+            elif request.headers.get('Access-Control-Allow-Credentials', False):
+                response.headers['Access-Control-Allow-Origin'] = origin
             else:
                 if any([o == "*" for o in service.cors_origins_for(method)]):
                     response.headers['Access-Control-Allow-Origin'] = '*'

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -28,7 +28,7 @@ class Klass(object):
     def post(self):
         return "moar squirels (take care)"
 
-cors_policy = {'origins': ('*',), 'enabled': True}
+cors_policy = {'origins': ('*',), 'enabled': True, 'credentials': True}
 
 cors_klass = Service(name='cors_klass',
                      path='/cors_klass',
@@ -217,6 +217,17 @@ class TestCORS(TestCase):
                 'Origin': 'lolnet.org',
                 'Access-Control-Request-Method': 'POST'})
         self.assertEqual(resp.headers['Access-Control-Allow-Origin'], '*')
+
+    def test_origin_is_not_wildcard_if_allow_credentials(self):
+        resp = self.app.options(
+            '/cors_klass',
+            status=200,
+            headers={
+                'Origin': 'lolnet.org',
+                'Access-Control-Request-Method': 'POST',
+                'Access-Control-Allow-Credentials': 'true'
+            })
+        self.assertEqual(resp.headers['Access-Control-Allow-Origin'], 'lolnet.org')
 
     def test_responses_include_an_allow_origin_header(self):
         resp = self.app.get('/squirel', headers={'Origin': 'notmyidea.org'})


### PR DESCRIPTION
It's not possible to return a wildcard when using credentials, so it's needed
to return the actual origin that's being authorized.

@natim r?
