### PR TITLE
Add validate_matchdict and validate_wtforms_schema to Cornice schemas.

### DIFF
--- a/cornice/ext/wtforms.py
+++ b/cornice/ext/wtforms.py
@@ -1,0 +1,52 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+def validate_wtforms_schema(form_schema, with_matchdict=False):
+    """Validates JSON data through WTForms schema.
+
+    For this function to properly work you have to install wtforms_json
+    package and add this code::
+
+        import wtforms_json
+        wtforms_json.init()
+
+    to the module where you define WTForms schemas, just after WTForms
+    imports.
+
+    Here's an example usage::
+
+        @view(
+            ...
+            validators=( validate_wtforms_schema(MyFormSchema), ),
+            ...
+        )
+
+    This function also has a keyword argument *with_matchdict* set
+    as default to False. Setting *with_matchdict* to True allows
+    to update JSON dictionary with values passed through
+    request.matchdict. It may be useful when you pass e.g. *id*
+    within your request.matchdict and you want to merge keys from
+    it to the JSON dictionary for further processing e.g.
+    to update SQLAlchemy model.
+    """
+    def wrapper(request):
+        try:
+            data = request.json
+        except Exception as e:
+            request.errors.add('body', 'exception', str(e))
+            return
+
+        if with_matchdict:
+            data.update(request.matchdict)
+
+        try:
+            form_obj = form_schema.from_json(data)
+        except Exception as e:
+            request.errors.add('form', 'exception', str(e))
+            return
+        if not form_obj.validate():
+            request.errors.add('form', 'validation', form_obj.errors)
+            return
+        request.form = form_obj
+    return wrapper

--- a/cornice/ext/wtforms.py
+++ b/cornice/ext/wtforms.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 def validate_wtforms_schema(form_schema, with_matchdict=False):
     """Validates JSON data through WTForms schema.
 

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -181,7 +181,7 @@ def validate_matchdict(matchdict_types):
     """Validates types of request.matchdict through matchdict_types
     dictionary.
 
-    matchdict_types dictionary should have it's values defined as
+    matchdict_types dictionary should have its values defined as
     callable type. Here's an example::
 
         @view(

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -198,5 +198,5 @@ def validate_matchdict(matchdict_types):
                 try:
                     typ(item)
                 except Exception as e:
-                    request.errors.add('matchdict', name, str(e))
+                    request.errors.add('path', name, str(e))
     return wrapper

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -191,62 +191,12 @@ def validate_matchdict(matchdict_types):
         )
     """
     def wrapper(request):
-        md = request.matchdict
-        for k, v in matchdict_types.iteritems():
-            if k in md.keys():
-                item = md.get(k)
+        matchdict = request.matchdict
+        for name, typ in matchdict_types.iteritems():
+            if name in matchdict.keys():
+                item = matchdict.get(name)
                 try:
-                    v(item)
+                    typ(item)
                 except Exception as e:
-                    request.errors.add('param', 'exception', str(e))
-    return wrapper
-
-
-def validate_wtforms_schema(form_schema, with_matchdict=False):
-    """Validates JSON data through WTForms schema.
-
-    For this function to properly work you have to install wtforms_json
-    package and add this code::
-
-        import wtforms_json
-        wtforms_json.init()
-
-    to the module where you define WTForms schemas, just after WTForms
-    imports.
-
-    Here's an example usage::
-
-        @view(
-            ...
-            validators=( validate_wtforms_schema(MyFormSchema), ),
-            ...
-        )
-
-    This function also has a keyword argument *with_matchdict* set
-    as default to False. Setting *with_matchdict* to True allows
-    to update JSON dictionary with values passed through
-    request.matchdict. It may be useful when you pass e.g. *id*
-    within your request.matchdict and you want to merge keys from
-    it to the JSON dictionary for further processing e.g.
-    to update SQLAlchemy model.
-    """
-    def wrapper(request):
-        try:
-            data = request.json
-        except Exception as e:
-            request.errors.add('data', 'json', str(e))
-            return
-
-        if with_matchdict:
-            data.update(request.matchdict)
-
-        try:
-            form_obj = form_schema.from_json(data)
-        except Exception as e:
-            request.errors.add('form', 'exception', str(e))
-            return
-        if not form_obj.validate():
-            request.errors.add('form', 'validation', form_obj.errors)
-            return
-        request.form = form_obj
+                    request.errors.add('matchdict', name, str(e))
     return wrapper

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,6 +95,7 @@ Documentation content
    validation
    builtin_validation
    sphinx
+   wtforms
    testing
    exhaustive_list
    exampledoc

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -284,7 +284,7 @@ fails. Here's a simple example for coercing email in matchdict::
     from cornice import Service
     import re
 	
-	FOO = {}
+    FOO = {}
 	
     foo = Service(name='foo', path='/foo/{id}')
     
@@ -296,7 +296,8 @@ fails. Here's a simple example for coercing email in matchdict::
         match = re.match("^[a-zA-Z0-9._%-+]+@[a-zA-Z0-9._%-]+.[a-zA-Z]{2,6}$", 
                          value)
         if match is None:
-            raise Exception('Value "{email}" is not proper email!'.format(value)
+            raise Exception('Value "{email}" is not proper email!'.format(
+                            email=value))
     
     
     @foo.get(validators=validate_matchdict({'email' : coerce_email}))
@@ -305,6 +306,35 @@ fails. Here's a simple example for coercing email in matchdict::
         """
         email = request.matchdict.get('email')
         return FOO[email]
+
+
+Here's another example for validating UUID in matchdict::
+
+    from cornice import Service
+    from uuid import UUID
+	
+    FOO = {}
+	
+    foo = Service(name='foo', path='/foo/{uuid}')
+    
+    
+    def coerce_uuid(value):
+        """Try to coerce value to UUID.
+        """
+        try:
+            UUID(str(value), version=4)
+        except:
+            raise Exception('Value {uuid_name} is not proper UUID!'.format(
+                            uuid_name=value))
+    
+    
+    @foo.get(validators=validate_matchdict({'uuid' : coerce_uuid}))
+    def get_foo(request):
+        """Returns foo value by UUID.
+        """
+        uuid = request.matchdict.get('uuid')
+        return FOO[uuid]
+    
 
 
 Validation using custom callables

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -232,6 +232,81 @@ like this::
         return 'Hello'
 
 
+Using WTForms
+~~~~~~~~~~~~~
+
+For using WTForms schema see :ref:`WTForms integration <wtforms>`.
+
+
+Validation of request.matchdict
+-------------------------------
+
+Sometimes it can be useful to validate types of variables passed through 
+**request.matchdict** e.g. when you have a Service method that depends upon 
+proper type of this variable.
+
+For example in CRUD-like services you often define methods (GET/PUT/DELETE) 
+whose URI includes an **id** that is used for querying the object. To ensure
+that your code doesn't break, you can validate coercion of the specified 
+**request.matchdict** variable to given type. For example::
+
+    from cornice import Service
+
+    USERS = {}
+    
+    user = Service(name='user', path='/user/{id}')
+    
+    @user.get(validators=validate_matchdict({'id' : int}))
+    def get_user(request):
+        """Returns user by id.
+        """
+        user_id = int(request.matchdict.get('id'))
+        return USERS[user_id]
+
+The **validate_matchdict** method ensures that **{id}** specified in the path
+for this service properly coerces to **int**. 
+
+**validate_matchdict** method takes coercion dictionary with it's key as the 
+name of request.matchdict key and value as type matchdict's variable should
+coerce to. If you have an URI that looks like this::
+
+    /users/{id}/friend/{name}
+
+the dictionary passed as argument to **validate_matchdict** could look like 
+this::
+
+    { 'id': int, 'name': str }
+
+Dictionary values doesn't have to be a builtin Python type, but can be any
+callable that performs coercion or raise an **Exception** when the coercion
+fails. Here's a simple example for coercing email in matchdict::
+
+    from cornice import Service
+    import re
+	
+	FOO = {}
+	
+    foo = Service(name='foo', path='/foo/{id}')
+    
+    
+    def coerce_email(value):
+        """Try to coerce value to email.
+        """
+        value = str(value)
+        match = re.match("^[a-zA-Z0-9._%-+]+@[a-zA-Z0-9._%-]+.[a-zA-Z]{2,6}$", 
+                         value)
+        if match is None:
+            raise Exception('Value "{email}" is not proper email!'.format(value)
+    
+    
+    @foo.get(validators=validate_matchdict({'email' : coerce_email}))
+    def get_foo(request):
+        """Returns foo value by email.
+        """
+        email = request.matchdict.get('email')
+        return FOO[email]
+
+
 Validation using custom callables
 ---------------------------------
 
@@ -246,7 +321,7 @@ Let's take an example: we want to make sure the incoming request has an
 
     def has_paid(request):
         if not 'X-Verified' in request.headers:
-            request.errors.add('header', 'X-Verified', 'You need to provied a token')
+            request.errors.add('header', 'X-Verified', 'You need to provide a token')
 
     @foo.get(validators=has_paid)
     def get_value(request):

--- a/docs/source/wtforms.rst
+++ b/docs/source/wtforms.rst
@@ -24,7 +24,7 @@ Let's start with importing required packages::
     from cornice.ext.wtforms import validate_wtforms_schema
     
     from wtforms import Form, StringField, FormField, IntegerField
-	from wtforms.validators import AnyOf, Length, DataRequired, Optional, \
+    from wtforms.validators import AnyOf, Length, DataRequired, Optional, \
 	                               InputRequired
 
 We have to import wtforms_json and initialize it after our WTForms imports::
@@ -121,7 +121,7 @@ Here's a quick example::
 
     
     @userupdate.put(
-   		content-type='application/json',
+   	    content-type='application/json',
         validators=validate_wtforms_schema(UserUpdateSchema, with_matchdict=True))
     def update_user(request):
         form = request.form

--- a/docs/source/wtforms.rst
+++ b/docs/source/wtforms.rst
@@ -1,0 +1,137 @@
+..  _wtforms:
+
+WTForms integration
+===================
+
+Using WTForms for JSON validation in Cornice can be achieved through
+`cornice.ext.wtforms` extension which specifies **validate_wtforms_schema**
+function.
+
+For this function to properly work you have to have WTForms installed and install
+`wtforms_json <https://github.com/kvesteri/wtforms-json>` package. You can do 
+this through::
+
+    pip install wtforms
+    pip install wtforms-json
+    
+Suppose you want to create a Service that allows you to send JSON data for User
+that should be validated through WTForms schema. Our User will also have address
+defined, so we can show how to validate nested JSON schemas through WTForms.
+
+Let's start with importing required packages::
+
+    from cornice import Service
+    from cornice.ext.wtforms import validate_wtforms_schema
+    
+    from wtforms import Form, StringField, FormField, IntegerField
+	from wtforms.validators import AnyOf, Length, DataRequired, Optional, \
+	                               InputRequired
+
+We have to import wtforms_json and initialize it after our WTForms imports::
+
+	import wtforms_json
+	wtforms_json.init()
+    
+Now let's define our WTForms schemas. We'll have two of them: 
+
+* AddressSchema - which will validate our user's address;
+* UserSchema - which will validate user data
+
+Here's the code::
+
+	class AddressSchema(Form):
+	    country = StringField(validators=[DataRequired()])
+	    state = StringField(validators=[Optional()])
+	    city = StringField(validators=[DataRequired()])
+	    postcode = StringField(validators=[DataRequired()])
+	    address = StringField(validators=[DataRequired()])
+
+
+	class UserSchema(Form):
+	    email = StringField(validators=[DataRequired()])
+	    password = StringField(validators=[DataRequired(), Length(min=8)])
+	    phone = StringField(validators=[Optional()])
+	    sex = StringField(validators=[AnyOf(['m', 'f'])]
+	    age = IntegerField(validators=[InputRequired()])
+	    name = StringField(validators=[DataRequired()])
+	    surname = StringField(validators=[DataRequired()])
+	    address = FormField(AddressSchema)
+
+This will allow us to pass a request with JSON data like this::
+
+    {
+        "email": "foo@bar.com",
+        "password": "somesecretpassword",
+        "phone": "4350983543",
+        "sex": "m",
+        "age": 42,
+        "name": "John",
+        "surname": "Doe",
+        "address": {
+            "country": "US",
+            "state": "Texas",
+            "city": "Houston",
+            "postcode": "77800",
+            "address": "Mirage St. 42"
+        }
+
+Let's define User service with POST method::
+
+    USERS = {}
+    
+    user = Service(name='user', path='/user')
+    
+    
+    @user.post(content-type='application/json',
+    	       validators=validate_wtforms_schema(UserSchema))
+    def post_user(request):
+        """Saves user.
+        """
+        form = request.form
+        user_email = form.data.get('email')
+        
+        USERS[user_email] = form.data
+        
+        return True
+
+
+After successful validation of the request input JSON data, you can access the
+WTForms schema through **request.form** and the validated data through
+**request.form.data** as you would when using WTForms. For more information on
+how to use validated data refer to `WTForms documentation 
+<https://wtforms.readthedocs.org/en/latest/>`.
+
+Interpolating with matchdict
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**validate_wtforms_schema** function also has a keyword argument 
+*with_matchdict* set as default to *False*. Setting *with_matchdict* to *True* 
+allows to update JSON dictionary with values passed through request.matchdict. 
+It may be useful when you pass e.g. *id* within your request.matchdict and you 
+want to merge keys from it to the JSON dictionary for further processing e.g.
+to update your data based upon this key.
+
+Here's a quick example::
+
+    class UserUpdateSchema(UserSchema):
+        id = IntegerField(validators=[InputRequired()]
+    
+
+    userupdate = Service(name='userupdate', path='/user/{id}')
+
+    
+    @userupdate.put(
+   		content-type='application/json',
+        validators=validate_wtforms_schema(UserUpdateSchema, with_matchdict=True))
+    def update_user(request):
+        form = request.form
+        user_id = form.data.get('id')
+        
+        # DO SOMETHING WITH user_id
+        ...
+
+
+That way you can interpolate variable **id** passed through **request.matchdict**
+with JSON data sent as PUT method body. **with_matchdict=True** will update
+input dictionary passed to the defined schema with key-value pairs from
+matchdict.


### PR DESCRIPTION
This pull request adds two useful validation methods:

* validate_matchdict - which allows simple checking types of arguments passed to view by request.matchdict
* validate_wtforms_schema - which allows validating JSON data through WTForms schema. Nested JSON dictionary validation requires importing and initializing wtforms_json extension within the module where WTForms schemas are defined.