### PR TITLE
Patch to resolve issue #190.

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -176,7 +176,7 @@ def validate_colander_schema(schema, request):
 
         return
 
-    for k,v in appstruct.items():
+    for k, v in appstruct.items():
         request.validated[k] = v
 
     # validate unknown

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -95,7 +95,7 @@ class CorniceSchema(object):
 
 def validate_colander_schema(schema, request):
     """Validates that the request is conform to the given schema"""
-    from colander import Invalid, Sequence, drop, null, Mapping
+    from colander import Invalid, Sequence, Mapping
 
     # CorniceSchema.colander_schema guarantees that we have a colander
     #  instance and not a class so we should use `typ` and not
@@ -162,7 +162,7 @@ def validate_colander_schema(schema, request):
     try:
         appstruct = schema.colander_schema.deserialize(cstruct)
     except Invalid as e:
-        for k, v in e.asdict().iteritems():
+        for k, v in e.asdict().items():
             v = '%s is missing' % k if v == 'Required' else v
 
             try:
@@ -176,7 +176,7 @@ def validate_colander_schema(schema, request):
 
         return
 
-    for k,v in appstruct.iteritems():
+    for k,v in appstruct.items():
         request.validated[k] = v
 
     # validate unknown

--- a/cornice/tests/schema.py
+++ b/cornice/tests/schema.py
@@ -1,6 +1,6 @@
 
 try:
-    from colander import MappingSchema, SchemaNode, String
+    from colander import MappingSchema, SchemaNode, String, drop
     COLANDER = True
 except ImportError:
     COLANDER = False
@@ -9,4 +9,4 @@ if COLANDER:
 
     class AccountSchema(MappingSchema):
         nickname = SchemaNode(String(), location='body', type='str')
-        city = SchemaNode(String(), location='body', type='str')
+        city = SchemaNode(String(), location='body', missing=drop, type='str')

--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -162,12 +162,15 @@ class TestResource(TestCase):
             User.schema = CorniceSchema.from_colander(
                 validationapp.FooBarSchema)
             result = self.patch("/users/1", status=400).json
-            self.assertEquals(
-                [(e['name'], e['description']) for e in result['errors']], [
-                    ('foo', 'foo is missing'),
-                    ('bar', 'bar is missing'),
-                    ('yeah', 'yeah is missing'),
-                ])
+            errors = sorted([
+                (e['name'], e['description']) for e in result['errors']
+            ])
+            expected = sorted([
+                ('foo', 'foo is missing'),
+                ('bar', 'bar is missing'),
+                ('yeah', 'yeah is missing'),
+            ])
+            self.assertEquals(errors, expected)
 
 
 class NonAutocommittingConfigurationTestResource(TestCase):

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -79,13 +79,13 @@ if COLANDER:
 
     class DefaultSchema(MappingSchema):
         foo = SchemaNode(String(), type='str', location="querystring",
-                         missing=drop, default='foo')
+                         missing='foo')
         bar = SchemaNode(String(), type='str', location="querystring",
                          default='bar')
 
     class DefaultValueSchema(MappingSchema):
         foo = SchemaNode(Int(), type="int")
-        bar = SchemaNode(Int(), type="int", default=10)
+        bar = SchemaNode(Int(), type="int", missing=10)
 
     class QsSchema(MappingSchema):
         foo = SchemaNode(String(), type='str', location="querystring",


### PR DESCRIPTION
Currently cornice iterates over colander schemas and deserializes each
node individually. I've refactored to allow colander to handle the
work, instead deserializing at the Schema rather than SchemaNodes.

There was also some confusion in the test regarding colander.default
and colander.missing. `default` is used on serialization while
`missing` is used on deserialization, which is what we want.