### PR TITLE
reworking colander schema validation [WIP]

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -1,180 +1,62 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-import webob.multidict
-
-from pyramid.path import DottedNameResolver
-from cornice.util import to_list, extract_request_data
+from cornice.util import extract_request_data
 
 
-class SchemaError(Exception):
+try:
+    import colander
+except ImportError:
     pass
+else:
 
+    class StrictMappingSchema(colander.MappingSchema):
+        @staticmethod
+        def schema_type():
+            return colander.Mapping(unknown='raise')
 
-class CorniceSchema(object):
-    """Defines a cornice schema"""
-
-    def __init__(self, _colander_schema, bind_request=True):
-        self._colander_schema = _colander_schema
-        self._colander_schema_runtime = None
-        self._bind_request = bind_request
-
-    @property
-    def colander_schema(self):
-        if not self._colander_schema_runtime:
-            schema = self._colander_schema
-            schema = DottedNameResolver(__name__).maybe_resolve(schema)
-            if callable(schema):
-                schema = schema()
-            self._colander_schema_runtime = schema
-        return self._colander_schema_runtime
-
-    def bind_attributes(self, request=None):
-        schema = self.colander_schema
-        if request and self._bind_request:
-            schema = schema.bind(request=request)
-        return schema.children
-
-    def get_attributes(self, location=("body", "header", "querystring"),
-                       required=(True, False),
-                       request=None):
-        """Return a list of attributes that match the given criteria.
-
-        By default, if nothing is specified, it will return all the attributes,
-        without filtering anything.
-        """
-        attributes = self.bind_attributes(request)
-
-        def _filter(attr):
-            if not hasattr(attr, "location"):
-                valid_location = 'body' in location
-            else:
-                valid_location = attr.location in to_list(location)
-            return valid_location and attr.required in to_list(required)
-
-        return list(filter(_filter, attributes))
-
-    def as_dict(self):
-        """returns a dict containing keys for the different attributes, and
-        for each of them, a dict containing information about them::
-
-            >>> schema.as_dict()  # NOQA
-            {'foo': {'type': 'string',
-                     'location': 'body',
-                     'description': 'yeah',
-                     'required': True},
-             'bar': {'type': 'string',
-                     'location': 'body',
-                     'description': 'yeah',
-                     'required': True}
-             # ...
-             }
-        """
-        attributes = self.bind_attributes()
-        schema = {}
-        for attr in attributes:
-            schema[attr.name] = {
-                'type': getattr(attr, 'type', attr.typ),
-                'name': attr.name,
-                'description': getattr(attr, 'description', ''),
-                'required': getattr(attr, 'required', False),
-            }
-
-        return schema
-
-    def unflatten(self, data):
-        return self.colander_schema.unflatten(data)
-
-    def flatten(self, data):
-        return self.colander_schema.flatten(data)
-
-    @classmethod
-    def from_colander(klass, colander_schema, **kwargs):
-        return CorniceSchema(colander_schema, **kwargs)
+    class CorniceSchema(colander.MappingSchema):
+        querystring = StrictMappingSchema(
+            default=colander.drop
+        )
+        headers = StrictMappingSchema(
+            default=colander.drop
+        )
+        body = StrictMappingSchema(
+            default=colander.drop
+        )
+        path = StrictMappingSchema(
+            default=colander.drop
+        )
 
 
 def validate_colander_schema(schema, request):
-    """Validates that the request is conform to the given schema"""
+    """Validates that the request conforms to the given schema"""
     from colander import Invalid, Sequence, drop, null, Mapping
 
-    # CorniceSchema.colander_schema guarantees that we have a colander
-    #  instance and not a class so we should use `typ` and not
-    #  `schema_type()` to determine the type.
-    schema_type = schema.colander_schema.typ
-    unknown = getattr(schema_type, 'unknown', None)
+    if not isinstance(schema, CorniceSchema):
+        raise TypeError(
+            'schema type is not a CorniceSchema'
+        )
 
-    if not isinstance(schema_type, Mapping):
-        raise SchemaError('colander schema type is not a Mapping: %s' %
-                          type(schema_type))
-
-    def _validate_fields(location, data):
-        if location == 'body':
-            try:
-                original = data
-                data = webob.multidict.MultiDict(schema.unflatten(data))
-                data.update(original)
-            except KeyError:
-                pass
-
-        if location == 'querystring':
-            try:
-                original = data
-                data = schema.unflatten(original)
-            except KeyError:
-                pass
-
-        for attr in schema.get_attributes(location=location,
-                                          request=request):
-            if attr.required and attr.name not in data and \
-               attr.default == null:
-                # missing
-                request.errors.add(location, attr.name,
-                                   "%s is missing" % attr.name)
-            else:
-                try:
-                    if attr.name not in data:
-                        if attr.default != null:
-                            deserialized = attr.deserialize(attr.serialize())
-                        else:
-                            deserialized = attr.deserialize()
-                    else:
-                        if (location == 'querystring' and
-                                isinstance(attr.typ, Sequence)):
-                            serialized = original.getall(attr.name)
-                        else:
-                            serialized = data[attr.name]
-                        deserialized = attr.deserialize(serialized)
-                except Invalid as e:
-                    # the struct is invalid
-                    try:
-                        request.errors.add(location, attr.name,
-                                           e.asdict()[attr.name])
-                    except KeyError:
-                        for k, v in e.asdict().items():
-                            if k.startswith(attr.name):
-                                request.errors.add(location, k, v)
-                else:
-                    if deserialized is not drop:
-                        request.validated[attr.name] = deserialized
-
-        if location == "body" and unknown == 'preserve':
-            for field, value in data.items():
-                if field not in request.validated:
-                    request.validated[field] = value
-
+    # compile the querystring, headers, body, path into an appstruct
+    #  for consumption by colander for validation
     qs, headers, body, path = extract_request_data(request)
+    initial_appstruct = {
+        'querystring': qs,
+        'headers': headers,
+        'body': body,
+        'path': path,
+    }
 
-    _validate_fields('path', path)
-    _validate_fields('header', headers)
-    _validate_fields('body', body)
-    _validate_fields('querystring', qs)
-
-    # validate unknown
-    if unknown == 'raise':
-        attrs = schema.get_attributes(location=('body', 'querystring'),
-                                      request=request)
-        params = list(qs.keys()) + list(body.keys())
-        msg = '%s is not allowed'
-        for param in set(params) - set([attr.name for attr in attrs]):
-            request.errors.add('body' if param in body else 'querystring',
-                               param, msg % param)
+    try:
+        cstruct = schema.serialize(initial_appstruct)
+        appstruct = schema.deserialize(cstruct)
+    except colander.Invalid as e:
+        for component_path, msg in e.asdict().items():
+            (location, _, name) = component_path.partition('.')
+            request.errors.add(
+                location, name, msg
+            )
+    else:
+        request.validated.update(appstruct)

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -1,8 +1,9 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-from cornice.util import extract_request_data
+from pyramid.compat import is_nonstr_iter
 
+from cornice.util import extract_request_data
 
 try:
     import colander
@@ -36,13 +37,13 @@ else:
                 result[k] = simple_cstruct_serialize(val[k])
             return result
         except (TypeError, AttributeError):
-            try:
+            if is_nonstr_iter(val):
                 # try iterable interpretation
                 result = []
                 for k in val:
                     result.append(simple_cstruct_serialize(k))
                 return result
-            except TypeError:
+            else:
                 return str(val)
 
 

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -4,116 +4,17 @@
 from cornice.errors import Errors
 from cornice.tests.support import TestCase
 from cornice.schemas import (
-    CorniceSchema, validate_colander_schema, SchemaError
+    CorniceSchema, validate_colander_schema, StrictMappingSchema
 )
 from cornice.util import extract_json_data
-import json
+
 
 try:
-    from colander import (
-        deferred,
-        Mapping,
-        MappingSchema,
-        Sequence,
-        SequenceSchema,
-        SchemaNode,
-        String,
-        Int,
-        OneOf,
-        drop
-    )
-    COLANDER = True
+    import colander
 except ImportError:
-    COLANDER = False
-
-if COLANDER:
-
-    @deferred
-    def deferred_validator(node, kw):
-        """
-        This is a deferred validator that changes its own behavior based on
-        request object being passed, thus allowing for validation of fields
-        depending on other field values.
-
-        This example shows how to validate a body field based on a dummy
-        header value, using OneOf validator with different choices
-        """
-        request = kw['request']
-        if request['x-foo'] == 'version_a':
-            return OneOf(['a', 'b'])
-        else:
-            return OneOf(['c', 'd'])
-
-    class TestingSchema(MappingSchema):
-        foo = SchemaNode(String(), type='str')
-        bar = SchemaNode(String(), type='str', location="body")
-        baz = SchemaNode(String(), type='str', location="querystring")
-
-    class WrongSchema(SequenceSchema):
-        items = TestingSchema()
-
-    class InheritedSchema(TestingSchema):
-        foo = SchemaNode(Int(), missing=1)
-
-    class ToBoundSchema(TestingSchema):
-        foo = SchemaNode(Int(), missing=1)
-        bazinga = SchemaNode(String(), type='str', location="body",
-                             validator=deferred_validator)
-
-    class DropSchema(MappingSchema):
-        foo = SchemaNode(String(), type='str', missing=drop)
-        bar = SchemaNode(String(), type='str')
-
-    class StrictMappingSchema(MappingSchema):
-        @staticmethod
-        def schema_type():
-            return Mapping(unknown='raise')
-
-    class StrictSchema(StrictMappingSchema):
-        foo = SchemaNode(String(), type='str', location="body", missing=drop)
-        bar = SchemaNode(String(), type='str', location="body")
-
-    class NestedSchema(MappingSchema):
-        egg = StrictSchema(location='querystring')
-        ham = StrictSchema(location='body')
-
-    class DefaultSchema(MappingSchema):
-        foo = SchemaNode(String(), type='str', location="querystring",
-                         missing=drop, default='foo')
-        bar = SchemaNode(String(), type='str', location="querystring",
-                         default='bar')
-
-    class DefaultValueSchema(MappingSchema):
-        foo = SchemaNode(Int(), type="int")
-        bar = SchemaNode(Int(), type="int", default=10)
-
-    class QsSchema(MappingSchema):
-        foo = SchemaNode(String(), type='str', location="querystring",
-                         missing=drop)
-
-    class StrictQsSchema(StrictMappingSchema):
-        foo = SchemaNode(String(), type='str', location="querystring",
-                         missing=drop)
-
-    imperative_schema = SchemaNode(Mapping())
-    imperative_schema.add(SchemaNode(String(), name='foo', type='str'))
-    imperative_schema.add(SchemaNode(String(), name='bar', type='str',
-                          location="body"))
-    imperative_schema.add(SchemaNode(String(), name='baz', type='str',
-                          location="querystring"))
-
-    class TestingSchemaWithHeader(MappingSchema):
-        foo = SchemaNode(String(), type='str')
-        bar = SchemaNode(String(), type='str', location="body")
-        baz = SchemaNode(String(), type='str', location="querystring")
-        qux = SchemaNode(String(), type='str', location="header")
-
-    class PreserveUnkownSchema(MappingSchema):
-        bar = SchemaNode(String(), type='str')
-
-        @staticmethod
-        def schema_type():
-            return Mapping(unknown='preserve')
+    pass
+else:
+    # colander is properly imported so we can proceed...
 
     def get_mock_request(body, get=None):
         # Construct a mock request with the given request body
@@ -140,265 +41,72 @@ if COLANDER:
 
     class TestSchemas(TestCase):
 
-        def test_colander_integration(self):
-            # not specifying body should act the same way as specifying it
-            schema = CorniceSchema.from_colander(TestingSchema)
-            body_fields = schema.get_attributes(location="body")
-            qs_fields = schema.get_attributes(location="querystring")
-
-            self.assertEqual(len(body_fields), 2)
-            self.assertEqual(len(qs_fields), 1)
-
-        def test_colander_integration_with_header(self):
-            schema = CorniceSchema.from_colander(TestingSchemaWithHeader)
-            all_fields = schema.get_attributes()
-            body_fields = schema.get_attributes(location="body")
-            qs_fields = schema.get_attributes(location="querystring")
-            header_fields = schema.get_attributes(location="header")
-
-            self.assertEqual(len(all_fields), 4)
-            self.assertEqual(len(body_fields), 2)
-            self.assertEqual(len(qs_fields), 1)
-            self.assertEqual(len(header_fields), 1)
-
-        def test_colander_inheritance(self):
-            """
-            support inheritance of colander.Schema
-            introduced in colander 0.9.9
-
-            attributes of base-classes with the same name than
-            subclass-attributes get overwritten.
-            """
-            base_schema = CorniceSchema.from_colander(TestingSchema)
-            inherited_schema = CorniceSchema.from_colander(InheritedSchema)
-
-            self.assertEqual(len(base_schema.get_attributes()),
-                             len(inherited_schema.get_attributes()))
-
-            def foo_filter(obj):
-                return obj.name == "foo"
-
-            base_foo = list(filter(foo_filter,
-                                   base_schema.get_attributes()))[0]
-            inherited_foo = list(filter(foo_filter,
-                                        inherited_schema.get_attributes()))[0]
-            self.assertTrue(base_foo.required)
-            self.assertFalse(inherited_foo.required)
-
-        def test_colander_bound_schemas(self):
-            dummy_request = {'x-foo': 'version_a'}
-            a_schema = CorniceSchema.from_colander(ToBoundSchema)
-            field = a_schema.get_attributes(request=dummy_request)[3]
-            self.assertEqual(field.validator.choices, ['a', 'b'])
-
-            other_dummy_request = {'x-foo': 'bazinga!'}
-            b_schema = CorniceSchema.from_colander(ToBoundSchema)
-            field = b_schema.get_attributes(request=other_dummy_request)[3]
-            self.assertEqual(field.validator.choices, ['c', 'd'])
-
-        def test_colander_bound_schema_rebinds_to_new_request(self):
-            dummy_request = {'x-foo': 'version_a'}
-            the_schema = CorniceSchema.from_colander(ToBoundSchema)
-            field = the_schema.get_attributes(request=dummy_request)[3]
-            self.assertEqual(field.validator.choices, ['a', 'b'])
-
-            other_dummy_request = {'x-foo': 'bazinga!'}
-            field = the_schema.get_attributes(request=other_dummy_request)[3]
-            self.assertEqual(field.validator.choices, ['c', 'd'])
-
-        def test_colander_request_is_bound_by_default(self):
-            the_schema = CorniceSchema.from_colander(ToBoundSchema)
-            dummy_request = {'x-foo': 'version_a'}
-            field = the_schema.get_attributes(request=dummy_request)[3]
-            # Deferred are resolved
-            self.assertNotEqual(type(field.validator), deferred)
-
-        def test_colander_request_is_not_bound_if_disabled(self):
-            the_schema = CorniceSchema.from_colander(ToBoundSchema,
-                                                     bind_request=False)
-            dummy_request = {'x-foo': 'version_a'}
-            field = the_schema.get_attributes(request=dummy_request)[3]
-            # Deferred are not resolved
-            self.assertEqual(type(field.validator), deferred)
-
         def test_imperative_colander_schema(self):
-            # not specifying body should act the same way as specifying it
-            schema = CorniceSchema.from_colander(imperative_schema)
-            body_fields = schema.get_attributes(location="body")
-            qs_fields = schema.get_attributes(location="querystring")
-
-            self.assertEqual(len(body_fields), 2)
-            self.assertEqual(len(qs_fields), 1)
+            imperative_schema = CorniceSchema()
+            imperative_schema['body'].add(
+                colander.SchemaNode(
+                    colander.String(),
+                    name='foo',
+                    default=colander.drop,
+                )
+            )
+            imperative_schema['body'].add(
+                colander.SchemaNode(
+                    colander.String(),
+                    name='bar'
+                )
+            )
+            imperative_schema['querystring'].add(
+                colander.SchemaNode(
+                    colander.String(),
+                    name='baz',
+                    default=colander.drop
+                )
+            )
 
             dummy_request = get_mock_request('{"bar": "some data"}')
-            validate_colander_schema(schema, dummy_request)
+            validate_colander_schema(imperative_schema, dummy_request)
+
+            self.assertEqual(len(dummy_request.errors), 0)
+            self.assertEqual(dummy_request.validated['body'],
+                             {'bar': 'some data'})
 
         def test_colander_schema_using_drop(self):
+            """ remove fields from validated data if they deserialize to
+            `colander.drop`.
             """
-            remove fields from validated data if they deserialize to colander's
-            `drop` object.
-            """
-            schema = CorniceSchema.from_colander(DropSchema)
+            from colander import SchemaNode, String
+
+            class DropSchema(StrictMappingSchema):
+                foo = SchemaNode(String(), missing=colander.drop)
+                bar = SchemaNode(String())
+
+            schema = CorniceSchema()
+            schema['body'] = DropSchema()
 
             dummy_request = get_mock_request('{"bar": "required_data"}')
             validate_colander_schema(schema, dummy_request)
 
-            self.assertNotIn('foo', dummy_request.validated)
-            self.assertIn('bar', dummy_request.validated)
+            self.assertNotIn('foo', dummy_request.validated['body'])
+            self.assertIn('bar', dummy_request.validated['body'])
             self.assertEqual(len(dummy_request.errors), 0)
 
         def test_colander_strict_schema(self):
-            schema = CorniceSchema.from_colander(StrictSchema)
+            from colander import SchemaNode, String
+
+            class StrictSchema(StrictMappingSchema):
+                foo = SchemaNode(String(), missing=colander.drop)
+                bar = SchemaNode(String())
+
+            schema = CorniceSchema()
+            schema['body'] = StrictSchema()
 
             dummy_request = get_mock_request(
-                '''
-                {"bar": "required_data", "foo": "optional_data",
-                "other": "not_wanted_data"}
-                ''')
-            validate_colander_schema(schema, dummy_request)
-
-            errors = dummy_request.errors
-            self.assertEqual(len(errors), 1)
-            self.assertEqual(errors[0], {'description': 'other is not allowed',
-                                         'location': 'body',
-                                         'name': 'other'})
-            self.assertIn('foo', dummy_request.validated)
-            self.assertIn('bar', dummy_request.validated)
-
-        def test_colander_schema_using_dotted_names(self):
-            """
-            Schema could be passed as string in view
-            """
-            schema = CorniceSchema.from_colander(
-                'cornice.tests.schema.AccountSchema')
-
-            dummy_request = get_mock_request('{"nickname": "john"}')
-            validate_colander_schema(schema, dummy_request)
-
-            self.assertIn('nickname', dummy_request.validated)
-            self.assertNotIn('city', dummy_request.validated)
-
-        def test_colander_nested_schema(self):
-            schema = CorniceSchema.from_colander(NestedSchema)
-
-            dummy_request = get_mock_request('{"ham": {"bar": "POST"}}',
-                                             {'egg.bar': 'GET'})
-            validate_colander_schema(schema, dummy_request)
-
-            qs_fields = schema.get_attributes(location="querystring")
-
-            errors = dummy_request.errors
-            self.assertEqual(len(errors), 0, errors)
-            self.assertEqual(len(qs_fields), 1)
-
-            expected = {'egg': {'bar': 'GET'},
-                        'ham': {'bar': 'POST'},
-                        }
-
-            self.assertEqual(expected, dummy_request.validated)
-
-        def test_colander_schema_using_defaults(self):
-            """
-            Schema could contains default values
-            """
-            schema = CorniceSchema.from_colander(DefaultSchema)
-
-            dummy_request = get_mock_request('', {'bar': 'test'})
-            validate_colander_schema(schema, dummy_request)
-
-            qs_fields = schema.get_attributes(location="querystring")
-
-            errors = dummy_request.errors
-            self.assertEqual(len(errors), 0)
-            self.assertEqual(len(qs_fields), 2)
-
-            expected = {'foo': 'foo', 'bar': 'test'}
-
-            self.assertEqual(expected, dummy_request.validated)
-
-            dummy_request = get_mock_request('', {'bar': 'test',
-                                                  'foo': 'test'})
-            validate_colander_schema(schema, dummy_request)
-
-            qs_fields = schema.get_attributes(location="querystring")
-
-            errors = dummy_request.errors
-            self.assertEqual(len(errors), 0)
-            self.assertEqual(len(qs_fields), 2)
-
-            expected = {'foo': 'test', 'bar': 'test'}
-
-            self.assertEqual(expected, dummy_request.validated)
-
-        def test_colander_schema_default_value(self):
-            # apply default value to field if the input for them is
-            # missing
-            schema = CorniceSchema.from_colander(DefaultValueSchema)
-            dummy_request = get_mock_request('{"foo": 5}')
-            validate_colander_schema(schema, dummy_request)
-
-            self.assertIn('bar', dummy_request.validated)
-            self.assertEqual(len(dummy_request.errors), 0)
-            self.assertEqual(dummy_request.validated['foo'], 5)
-            # default value should be available
-            self.assertEqual(dummy_request.validated['bar'], 10)
-
-        def test_only_mapping_is_accepted(self):
-            schema = CorniceSchema.from_colander(WrongSchema)
-            dummy_request = get_mock_request('', {'foo': 'test',
-                                                  'bar': 'test'})
-            self.assertRaises(SchemaError,
-                              validate_colander_schema, schema, dummy_request)
-
-            # We shouldn't accept a MappingSchema if the `typ` has
-            #  been set to something else:
-            schema = CorniceSchema.from_colander(
-                MappingSchema(
-                    Sequence,
-                    SchemaNode(String(), name='foo'),
-                    SchemaNode(String(), name='bar'),
-                    SchemaNode(String(), name='baz')
-                )
+                '''{"bar": "required_data", "foo": "optional_data",
+                "other": "not_wanted_data"}'''
             )
-            self.assertRaises(SchemaError,
-                              validate_colander_schema, schema, dummy_request)
-
-        def test_extra_params_qs(self):
-            schema = CorniceSchema.from_colander(QsSchema)
-            dummy_request = get_mock_request('', {'foo': 'test',
-                                                  'bar': 'test'})
-            validate_colander_schema(schema, dummy_request)
-
-            errors = dummy_request.errors
-            self.assertEqual(len(errors), 0)
-
-            expected = {'foo': 'test'}
-            self.assertEqual(expected, dummy_request.validated)
-
-        def test_extra_params_qs_strict(self):
-            schema = CorniceSchema.from_colander(StrictQsSchema)
-            dummy_request = get_mock_request('', {'foo': 'test',
-                                                  'bar': 'test'})
             validate_colander_schema(schema, dummy_request)
 
             errors = dummy_request.errors
             self.assertEqual(len(errors), 1)
-            self.assertEqual(errors[0], {'description': 'bar is not allowed',
-                                         'location': 'querystring',
-                                         'name': 'bar'})
-
-            expected = {'foo': 'test'}
-            self.assertEqual(expected, dummy_request.validated)
-
-        def test_validate_colander_schema_can_preserve_unknown_fields(self):
-            schema = CorniceSchema.from_colander(PreserveUnkownSchema)
-
-            data = json.dumps({"bar": "required_data", "optional": "true"})
-            dummy_request = get_mock_request(data)
-            validate_colander_schema(schema, dummy_request)
-
-            self.assertDictEqual(dummy_request.validated, {
-                "bar": "required_data",
-                "optional": "true"
-            })
-            self.assertEqual(len(dummy_request.errors), 0)
+            self.assertNotIn('body', dummy_request.validated)


### PR DESCRIPTION
Okay, due to all the issues and comments surrounding colander validation I started working on a replacement.  Basically a lot of things were being done in Cornice when they could have easily been left to Colander (like iterating over child elements).  The schema.py file is now 62 lines where the old one was 180.  The 4 main components (querystring, headers, body, and path) are grouped into one structure and passed through a single schema for validation tests.  Each of those 4 components, if validated, are moved to `request.validated`.  Any errors are put in `request.errors`.

This is obviously a huge change from the previous method, so I wanted to get some input before I complete all aspects of this PR (please ignore the failing tests for the moment).

I modified a few existing tests to kind of demonstrate how the system works on validating the body but obviously more are needed to test validating the other 3 types.

This deals with the following issues: #310, #211, #190, #327, #193, #249 

Perhaps we could support #173 by calling unflatten in the validator.