### PR TITLE
Make sure JSON string values come through consistently as unicode.

### DIFF
--- a/cornice/tests/test_util.py
+++ b/cornice/tests/test_util.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from cornice import util
+from cornice.tests.support import TestCase
+
+class StubRequestWithBody(object):
+    def __init__(self, body):
+        self.body = body
+
+class TestExtractedJSONValueTypes(TestCase):
+    """Make sure that all JSON string values extracted from the request
+      are unicode when running using PY2.
+    """
+
+    def test_extracted_json_values(self):
+        """Extracted JSON values are unicode in PY2."""
+
+        if not util.PY2:
+            return
+
+        valid_json_str = '{"foo": "bar", "currency": "\xe2\x82\xac"}'
+        request = StubRequestWithBody(valid_json_str)
+        data = util.extract_json_data(request)
+        self.assertEqual(type(data['foo']), unicode)
+        self.assertEqual(type(data['currency']), unicode)
+        self.assertEqual(data['currency'], u'€')


### PR DESCRIPTION
If you look at the current impl of `util.extract_json_data` it passes request.body directly to `simplejson.loads`.

Under PY2, when passed a string, `loads` has the [documented behaviour](https://simplejson.readthedocs.io/en/latest/#simplejson.loads) of varying the type of returned string values depending on the content of the strings:

> If s is a str then decoded JSON strings that contain only ASCII characters may be parsed as str for performance and memory reasons. If your code expects only unicode the appropriate solution is decode s to unicode prior to calling loads.

You can see the behaviour with e.g.:

```
>>> import simplejson
>>> simplejson.loads('{"foo":"ear"}')
{'foo': 'ear'}
>>> simplejson.loads('{"foo":"€ar"}')
{'foo': u'\u20acar'}
>>> simplejson.loads(u'{"foo":"ear"}')
{u'foo': u'ear'}
>>> simplejson.loads(u'{"foo":"€ar"}')
{u'foo': u'\u20acar'}
```

The commit attached follows the advice of "decode s to unicode prior to calling loads" (when running under PY2 and when `request.body` is a `str`).
