### PR TITLE
Restore old semantics of location='path'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,16 @@ CHANGELOG
 
 - Nothing changed yet.
 
+2.0.3 (unreleased)
+==================
+
+**Bug fixes**
+
+- To maintain consistency with cornice 1.2 as to the semantics of
+  ``location='path'``, change ``cornice.validators.extract_cstruct``
+  so that it places ``request.matchdict`` (rather than
+  ``request.path``) into ``cstruct['path']``. (#411)
+
 
 2.0.2 (2016-10-25)
 ==================

--- a/cornice/validators/__init__.py
+++ b/cornice/validators/__init__.py
@@ -51,7 +51,7 @@ def extract_cstruct(request):
 
     cstruct = {'method': request.method,
                'url': request.url,
-               'path': request.path,
+               'path': request.matchdict,
                'body': body}
 
     for sub, attr in (('querystring', 'GET'),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -235,6 +235,12 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         self.assertEqual(response.json['errors'][0]['description'],
                          'Invalid email length')
 
+    def test_validated_path_content_from_schema(self):
+        # Test validation request.matchdict.  (See #411)
+        app = TestApp(main({}))
+        response = app.get('/item/42', status=200)
+        self.assertEqual(response.json, {'item_id': 42})
+
     def test_content_type_with_no_body_should_pass(self):
         app = TestApp(main({}))
 

--- a/tests/validationapp.py
+++ b/tests/validationapp.py
@@ -255,6 +255,19 @@ if COLANDER:
     def newsletter(request):
         return request.validated
 
+    class ItemPathSchema(MappingSchema):
+        item_id = SchemaNode(Integer())
+
+    class ItemSchema(MappingSchema):
+        path = ItemPathSchema()
+
+    item_service = Service(name='item', path='/item/{item_id}')
+
+    @item_service.get(schema=ItemSchema,
+                      validators=(colander_validator,))
+    def item(request):
+        return request.validated['path']
+
 
 def includeme(config):
     config.include("cornice")


### PR DESCRIPTION
Change ``extract_cstruct`` so as to put ``request.matchdict`` (rather than ``request.path``) into ``cstruct['path']``.

This is to maintain semantic consistency with Cornice 1.2, where ``location='path'`` meant to extract parameters from ``matchdict``.

See #411 for further discussion.