### PR TITLE
Support passing colander schema nodes (instances)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,19 @@ CHANGELOG
 2.0.3 (unreleased)
 ==================
 
+**Enhancements**
+
+- ``Cornice.validators.colander_validator`` and
+  ``cornice.validators.colander_body_validator`` now accept colander
+  schema node instances.  Previously only schema classes were
+  accepted.  For some discussion see #412.
+
+**Deprecations**
+
+- Passing schema classes to ``Cornice.validators.colander_validator`` and
+  ``cornice.validators.colander_body_validator`` is now deprecated.
+  (See above.)
+
 **Bug fixes**
 
 - To maintain consistency with cornice 1.2 as to the semantics of

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -59,7 +59,7 @@ To describe a schema, using Colander and Cornice, here is how you can do:
     class SignupSchema(colander.MappingSchema):
         username = colander.SchemaNode(colander.String())
 
-    @signup.post(schema=SignupSchema, validators=(colander_body_validator,))
+    @signup.post(schema=SignupSchema(), validators=(colander_body_validator,))
     def signup_post(request):
         username = request.validated['username']
         return {'success': True}
@@ -120,7 +120,7 @@ The ``request.validated`` hences reflects this additional level.
 
     signup = cornice.Service()
 
-    @signup.post(schema=SignupSchema, validators=(colander_validator,))
+    @signup.post(schema=SignupSchema(), validators=(colander_validator,))
     def signup_post(request):
         username = request.validated['body']['username']
         referrer = request.validated['querystring']['referrer']
@@ -161,7 +161,7 @@ The general pattern in this case is:
         return extract_data_somehow(request)
 
 
-    @service.post(schema=MySchema,
+    @service.post(schema=MySchema(),
                   deserializer=my_deserializer,
                   validators=(colander_body_validator,))
     def post(request):

--- a/docs/source/upgrading.rst
+++ b/docs/source/upgrading.rst
@@ -88,7 +88,7 @@ Now:
     class SignupSchema(colander.MappingSchema):
         username = colander.SchemaNode(colander.String())
 
-    @signup.post(schema=SignupSchema, validators=(colander_body_validator,))
+    @signup.post(schema=SignupSchema(), validators=(colander_body_validator,))
     def signup_postt(request):
         username = request.validated['username']
         return {'success': True}
@@ -145,7 +145,7 @@ Now:
 
     signup = cornice.Service()
 
-    @signup.post(schema=SignupSchema, validators=(colander_validator,))
+    @signup.post(schema=SignupSchema(), validators=(colander_validator,))
     def signup_post(request):
         username = request.validated['body']['username']
         referrer = request.validated['querystring']['referrer']
@@ -207,7 +207,7 @@ Deserializers are still defined via the same API:
             return dict(zip(['foo', 'bar', 'yeah'], values))
         request.errors.add(location='body', description='Unsupported content')
 
-    @myservice.post(schema=FooBarSchema,
+    @myservice.post(schema=FooBarSchema(),
                     deserializer=dummy_deserializer,
                     validators=(my_validator,))
 

--- a/tests/validationapp.py
+++ b/tests/validationapp.py
@@ -170,7 +170,7 @@ if COLANDER:
     class SignupSchema(MappingSchema):
         username = SchemaNode(String())
 
-    @signup.post(schema=SignupSchema, validators=(colander_body_validator,))
+    @signup.post(schema=SignupSchema(), validators=(colander_body_validator,))
     def signup_post(request):
         return request.validated
 
@@ -206,7 +206,7 @@ if COLANDER:
 
     foobar = Service(name="foobar", path="/foobar")
 
-    @foobar.post(schema=RequestSchema, validators=(colander_validator,))
+    @foobar.post(schema=RequestSchema(), validators=(colander_validator,))
     def foobar_post(request):
         return {"test": "succeeded"}
 
@@ -226,7 +226,7 @@ if COLANDER:
 
     foobaz = Service(name="foobaz", path="/foobaz")
 
-    @foobaz.get(schema=QSSchema, validators=(colander_validator,))
+    @foobaz.get(schema=QSSchema(), validators=(colander_validator,))
     def foobaz_get(request):
         return {"field": request.validated['querystring']['field']}
 
@@ -250,7 +250,7 @@ if COLANDER:
 
     email_service = Service(name='newsletter', path='/newsletter')
 
-    @email_service.post(schema=NewsletterPayload,
+    @email_service.post(schema=NewsletterPayload(),
                         validators=(colander_validator,))
     def newsletter(request):
         return request.validated
@@ -263,7 +263,7 @@ if COLANDER:
 
     item_service = Service(name='item', path='/item/{item_id}')
 
-    @item_service.get(schema=ItemSchema,
+    @item_service.get(schema=ItemSchema(),
                       validators=(colander_validator,))
     def item(request):
         return request.validated['path']


### PR DESCRIPTION
Previously, ``colander_validator`` (and ``colander_body_validator``) expected ``schema`` to be a colander schema class.  This change supports setting ``schema`` to a schema node (or instance.)

This behavior is more flexible.  (Schema node instances can be constructed in a variety of ways, including [imperative definition](http://docs.pylonsproject.org/projects/colander/en/latest/basics.html#defining-a-schema-imperatively), and [schema binding](http://docs.pylonsproject.org/projects/colander/en/latest/binding.html).)

Also, now, a ``DeprecationWarning`` is issued when ``schema`` is set to a class rather than an instance.

See #412 for further discussion.