### PR TITLE
Fix parsing of 'Access-Control-Request-Headers' header

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,11 @@ CHANGELOG
 2.3.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**Bug fixes**
+
+- Fix ``cornice.cors.get_cors_preflight_view`` to make it parse
+  `Access-Control-Request-Headers` header correctly event if its value
+  contains zero number of white spaces between commas (#422)
 
 
 2.2.0 (2016-11-25)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -81,3 +81,4 @@ Cornice:
 * Vincent Fretin <vincent.fretin@gmail.com>
 * Ymage <o2heltem@gmail.com>
 * Volodymyr Maksymiv <vmaksymiv@quintagroup.com>
+* Sergey Safonov <spoof@spoofa.info>

--- a/cornice/cors.py
+++ b/cornice/cors.py
@@ -39,7 +39,7 @@ def get_cors_preflight_view(service):
             request.headers.get('Access-Control-Request-Headers', ()))
 
         if requested_headers:
-            requested_headers = map(str.strip, requested_headers.split(', '))
+            requested_headers = map(str.strip, requested_headers.split(','))
 
         if requested_method not in service.cors_supported_methods:
             request.errors.add('header', 'Access-Control-Request-Method',


### PR DESCRIPTION
Cornice parses this header by using the non flexible way as HTTP specification
required. Specifications says Access-Control-Request-Headers header
can have any number of LWS (Linear White Spaces) between commas.
But Cornice strictly waits for 'comma with space' delimiter.
It leads to an error for header values like
 `Access-Control-Request-Headers: header1,header2,header3` when 
`cors_expose_all_headers=True`, even if any of these headers (or all of them) 
persist in `service.cors_headers` attribute.

Is it necessary to write tests for this situation? (I see no such tests for other headers)