### PR TITLE
Add custom JSON content-type support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ CHANGELOG
 2.3.0 (unreleased)
 ==================
 
+**Enhancements**
+
+- Add support for validation with specific JSON Content-Types
+  (i.e application/merge-patch+json).
+
 **Bug fixes**
 
 - Fix ``cornice.cors.get_cors_preflight_view`` to make it parse

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Cornice:
 * David Charboneau <david@thecharboneaus.net>
 * David Grant <seizethedave@gmail.com>
 * Elias <elias@stupeflix.com>
+* Gabriela Surita <gsurita@mozilla.com>
 * Gael Pasgrimaud <gael@gawel.org>
 * George V. Reilly <george@reilly.org>
 * Graham Higgins <gjh-github@bel-epa.com>

--- a/cornice/validators/__init__.py
+++ b/cornice/validators/__init__.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import re
+
 from webob.multidict import MultiDict
 from cornice.validators._colander import (
     validator as colander_validator,
@@ -31,11 +32,11 @@ def extract_cstruct(request):
     :returns: A mapping containing most request attributes.
     :rtype: dict
     """
+    is_json = re.match('^application/(.*?)json$', str(request.content_type))
+
     if request.content_type == 'application/x-www-form-urlencoded':
         body = request.POST.mixed()
-
-    elif (request.content_type and
-          not re.match('^application/(.*?)json$', str(request.content_type))):
+    elif request.content_type and not is_json:
         body = request.body
     else:
         if request.body:

--- a/cornice/validators/__init__.py
+++ b/cornice/validators/__init__.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
+import re
 from webob.multidict import MultiDict
 from cornice.validators._colander import (
     validator as colander_validator,
@@ -33,7 +34,8 @@ def extract_cstruct(request):
     if request.content_type == 'application/x-www-form-urlencoded':
         body = request.POST.mixed()
 
-    elif request.content_type and request.content_type != 'application/json':
+    elif (request.content_type and
+          not re.match('^application/(.*?)json$', str(request.content_type))):
         body = request.body
     else:
         if request.body:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -396,6 +396,15 @@ class TestRequestDataExtractors(LoggingCatcher, TestCase):
         })
         self.assertEqual(response.json['username'], 'man')
 
+    def test_valid_nonstandard_json(self):
+        app = self.make_ordinary_app()
+        response = app.post_json(
+            '/signup',
+            {'username': 'man'},
+            headers={'content-type': 'application/merge-patch+json'}
+        )
+        self.assertEqual(response.json['username'], 'man')
+
     def test_invalid_json(self):
         app = self.make_ordinary_app()
         response = app.post('/signup',


### PR DESCRIPTION
This adds support to a [series of JSON Content-Type variations](http://www.iana.org/assignments/media-types/media-types.xhtml#application) which can be validated as common JSON requests.

Original issue: https://github.com/Kinto/kinto/issues/979
Related to: https://github.com/Kinto/kinto/pull/981

r? @leplatrem 
