### PR TITLE
Fix inconsistency in cornice.service.decorate_view() arguments

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,12 @@ CHANGELOG
   `Access-Control-Request-Headers` header correctly event if its value
   contains zero number of white spaces between commas (#422)
 
+**Internal changes**
+
+- Clean-up an inconsistency in ``cornice.service.decorate_view()`` function
+  where ``acl`` and ``factory`` were expected as view arguments (whereas
+  deprecated since 1.0)
+
 
 2.2.0 (2016-11-25)
 ==================

--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -213,17 +213,11 @@ def register_service_views(config, service):
         if service.cors_enabled:
             args['validators'].insert(0, cors_validator)
 
-        decorated_view = decorate_view(view, dict(args), method)
+        decorated_view = decorate_view(view, dict(args), method, route_args)
 
         for item in cornice_parameters:
             if item in args:
                 del args[item]
-
-        # These attributes are used in routes not views
-        deprecated_attrs = ['acl', 'factory', 'traverse']
-        for attr in deprecated_attrs:
-            if attr in args:
-                args.pop(attr)
 
         # filter predicates defined on Resource
         route_predicates = config.get_predlist('route').sorter.names

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -505,10 +505,11 @@ class TestService(TestCase):
 
     def test_decorate_view_factory(self):
 
-        args = {'factory': u'TheFactoryMethodCalledByPyramid',
-                'klass': DummyAPI}
+        args = {'klass': DummyAPI}
+        route_args = {'factory': u'TheFactoryMethodCalledByPyramid'}
 
-        decorated_view = decorate_view('collection_get', args, 'GET')
+        decorated_view = decorate_view('collection_get', args,
+                                       'GET', route_args)
         dummy_request = DummyRequest()
         ret = decorated_view(dummy_request)
         self.assertEqual(ret, ['douggy', 'rusty'])


### PR DESCRIPTION
Some explanation here:

* some parts of the code were relying on the fact that `acl` and `factory` were passed as view args (and removed at last moment). 
* I changed the code so that `acl` and `factory` never end-up as view arguments (as introduced in version 1.0)