### PR TITLE
Configure setup.py to require a minimum version of Pyramid at 1.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
-requires = ['pyramid',  'simplejson']
+requires = ['pyramid>=1.7',  'simplejson']
 
 entry_points = ""
 package_data = {}


### PR DESCRIPTION
I noticed today that Cornice does not work with Pyramid 1.5, as it
tries to configure Pyramid with require_csrf which was introduced
in Pyramid 1.7[0]. If this minimum version of Pyramid is not used,
users will receive Tracebacks similar to this:

Traceback (most recent call last):
  File "/usr/bin/pserve", line 9, in <module>
    load_entry_point('pyramid', 'console_scripts', 'pserve')()
  File "/usr/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 58, in main
    return command.run()
  File "/usr/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 328, in run
    global_conf=vars)
  File "/usr/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 363, in loadapp
    return loadapp(app_spec, name=name, relative_to=relative_to, **kw)
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/usr/lib/python2.7/site-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/home/vagrant/bodhi/bodhi/server/__init__.py", line 348, in main
    config.scan('bodhi.server.views')
  File "/usr/lib/python2.7/site-packages/pyramid/config/__init__.py", line 930, in scan
    ignore=ignore)
  File "/usr/lib/python2.7/site-packages/venusian/__init__.py", line 206, in scan
    invoke(modname, name, ob)
  File "/usr/lib/python2.7/site-packages/venusian/__init__.py", line 165, in invoke
    callback(self, name, ob)
  File "/usr/lib/python2.7/site-packages/cornice/service.py", line 210, in callback
    config.add_cornice_service(self)
  File "/usr/lib/python2.7/site-packages/pyramid/util.py", line 535, in wrapper
    result = wrapped(self, *arg, **kw)
  File "/usr/lib/python2.7/site-packages/cornice/pyramidhook.py", line 279, in register_service_views
    config.commit()
  File "/usr/lib/python2.7/site-packages/pyramid/config/__init__.py", line 610, in commit
    self.action_state.execute_actions(introspector=self.introspector)
  File "/usr/lib/python2.7/site-packages/pyramid/config/__init__.py", line 1048, in execute_actions
    for action in resolveConflicts(self.actions):
  File "/usr/lib/python2.7/site-packages/pyramid/config/__init__.py", line 1132, in resolveConflicts
    discriminator = undefer(action['discriminator'])
  File "/usr/lib/python2.7/site-packages/pyramid/registry.py", line 250, in undefer
    v = v.resolve()
  File "/usr/lib/python2.7/site-packages/pyramid/registry.py", line 242, in resolve
    return self.func()
  File "/usr/lib/python2.7/site-packages/pyramid/config/views.py", line 1150, in discrim_func
    order, preds, phash = predlist.make(self, **pvals)
  File "/usr/lib/python2.7/site-packages/pyramid/config/util.py", line 156, in make
    raise ConfigurationError('Unknown predicate values: %r' % (kw,))
pyramid.exceptions.ConfigurationError: Unknown predicate values: {'require_csrf': False}

[0] https://docs.pylonsproject.org/projects/pyramid/en/latest/_modules/pyramid/config/views.html

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>