### PR TITLE
Require venusian in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
-requires = ['pyramid>=1.7',  'simplejson', 'six']
+requires = ['pyramid>=1.7',  'simplejson', 'six', 'venusian']
 
 entry_points = ""
 package_data = {}


### PR DESCRIPTION
Two modules import venusian, but it wasn't required in the
setup.py. This commit adds it there.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>