### PR TITLE
allow services to reuse existing pyramid routes instead ofcreating new ones every time

### DIFF
--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -162,9 +162,14 @@ def register_service_views(config, service):
     :param service: the service object containing the definitions
     """
     route_name = service.name
-    services = config.registry.cornice_services
+    existing_route = service.pyramid_route
     prefix = config.route_prefix or ''
-    services[prefix + service.path] = service
+    services = config.registry.cornice_services
+    if existing_route:
+        route_name = existing_route
+        services[prefix + '__cornice' + existing_route] = service
+    else:
+        services[prefix + service.path] = service
 
     # before doing anything else, register a view for the OPTIONS method
     # if we need to
@@ -198,7 +203,9 @@ def register_service_views(config, service):
         if hasattr(service, predicate):
             route_args[predicate] = getattr(service, predicate)
 
-    config.add_route(route_name, service.path, **route_args)
+    # register route when not using exiting pyramid routes
+    if not existing_route:
+        config.add_route(route_name, service.path, **route_args)
 
     # 2. register view(s)
 

--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -62,6 +62,10 @@ def add_resource(klass, depth=1, **kw):
 
     services = {}
 
+    if (('collection_pyramid_route' in kw or 'pyramid_route' in kw) and
+            ('collection_path' in kw or 'path' in kw)):
+        raise ValueError('You use either paths or route names, not both')
+
     if 'collection_path' in kw:
         if kw['collection_path'] == kw['path']:
             msg = "Warning: collection_path and path are not distinct."
@@ -70,6 +74,14 @@ def add_resource(klass, depth=1, **kw):
         prefixes = ('', 'collection_')
     else:
         prefixes = ('',)
+
+    if 'collection_pyramid_route' in kw:
+        if kw['collection_pyramid_route'] == kw['pyramid_route']:
+            msg = "Warning: collection_pyramid_route and " \
+                  "pyramid_route are not distinct."
+            warnings.warn(msg)
+
+        prefixes = ('', 'collection_')
 
     for prefix in prefixes:
 

--- a/cornice/service.py
+++ b/cornice/service.py
@@ -48,6 +48,9 @@ class Service(object):
     :param path:
         The path the service is available at. Should also be unique.
 
+    :param pyramid_route:
+        Use existing pyramid route instead of creating new one.
+
     :param renderer:
         The renderer that should be used by this service. Default value is
         'simplejson'.
@@ -153,12 +156,18 @@ class Service(object):
     list_arguments = ('validators', 'filters', 'cors_headers', 'cors_origins')
 
     def __repr__(self):
-        return u'<Service %s at %s>' % (self.name, self.path)
+        return u'<Service %s at %s>' % (
+            self.name, self.pyramid_route or self.path)
 
-    def __init__(self, name, path, description=None, cors_policy=None, depth=1,
-                 **kw):
+    def __init__(self, name, path=None, description=None, cors_policy=None,
+                 depth=1, pyramid_route=None, **kw):
         self.name = name
         self.path = path
+        self.pyramid_route = pyramid_route
+
+        if not self.path and not self.pyramid_route:
+            raise TypeError('You need to pass path or pyramid_route arg')
+
         self.description = description
         self.cors_expose_all_headers = True
         self._cors_enabled = None

--- a/cornice/util.py
+++ b/cornice/util.py
@@ -199,9 +199,7 @@ def current_service(request):
     if request.matched_route:
         services = request.registry.cornice_services
         pattern = request.matched_route.pattern
-        try:
-            service = services[pattern]
-        except KeyError:
-            return None
-        else:
-            return service
+        name = request.matched_route.name
+        # try pattern first, then route name else return None
+        service = services.get(pattern, services.get('__cornice' + name))
+        return service

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -84,6 +84,35 @@ class TestResourceWarning(TestCase):
         msg = "Warning: collection_path and path are not distinct."
         mocked_warn.assert_called_with(msg)
 
+    @mock.patch('warnings.warn')
+    def test_routes_clash(self, mocked_warn):
+        @resource(collection_pyramid_route='some_route',
+                  pyramid_route='some_route', name='bad_thing_service')
+        class BadThing(object):
+            def __init__(self, request, context=None):
+                pass
+
+        msg = "Warning: collection_pyramid_route and " \
+              "pyramid_route are not distinct."
+        mocked_warn.assert_called_with(msg)
+
+
+    def test_routes_with_paths(self):
+        with self.assertRaises(ValueError):
+            @resource(collection_path='/some_route',
+                      pyramid_route='some_route', name='bad_thing_service')
+            class BadThing(object):
+                def __init__(self, request, context=None):
+                    pass
+
+    def test_routes_with_paths_reversed(self):
+        with self.assertRaises(ValueError):
+            @resource(collection_pyramid_route='some_route',
+                      path='/some_route', name='bad_thing_service')
+            class BadThing(object):
+                def __init__(self, request, context=None):
+                    pass
+
 
 class TestResource(TestCase):
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -59,6 +59,10 @@ class TestService(TestCase):
         service = Service("coconuts", "/migrate")
         self.assertEqual(repr(service), '<Service coconuts at /migrate>')
 
+    def test_representation_path(self):
+        service = Service("coconuts", pyramid_route="some_route")
+        self.assertEqual(repr(service), '<Service coconuts at some_route>')
+
     def test_get_arguments(self):
         service = Service("coconuts", "/migrate")
         # not specifying anything, we should get the default values


### PR DESCRIPTION
Services: allow services to reuse existing pyramid routes instead ofcreating new ones every time

I believe this will fix: 

https://github.com/Cornices/cornice/issues/137 and https://github.com/Cornices/cornice/issues/473 among things.