### PR TITLE
content-type/accept `text/json`?

### DIFF
--- a/cornice/util.py
+++ b/cornice/util.py
@@ -35,7 +35,7 @@ class _JsonRenderer(object):
       .. _`[2]`: http://pyramid.readthedocs.io/en/latest/narr/renderers.html \
                  #serializing-custom-objects
     """
-    acceptable = ('application/json', 'text/json', 'text/plain')
+    acceptable = ('application/json', 'text/plain')
 
     def __call__(self, data, context):
         """Serialise the ``data`` with the Pyramid renderer."""

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -217,7 +217,7 @@ value of accepted media types:
 
     def _accept(request):
         # interact with request if needed
-        return ("text/xml", "text/json")
+        return ("text/xml", "application/json")
 
     @service.get(accept=_accept)
     def foo(request):
@@ -241,7 +241,7 @@ When using the default json `error_handler`, the response might look like this::
             {
                 'location': 'header',
                 'name': 'Accept',
-                'description': 'Accept header should be one of ["text/xml", "text/json"]'
+                'description': 'Accept header should be one of ["text/xml", "application/json"]'
             }
         ]
     }

--- a/tests/test_imperative_resource.py
+++ b/tests/test_imperative_resource.py
@@ -98,7 +98,7 @@ class TestResource(TestCase):
 
         add_view(UserImp.get, renderer='json')
         add_view(UserImp.get, renderer='jsonp', accept='application/javascript')
-        add_view(UserImp.collection_post, renderer='json', accept='text/json')
+        add_view(UserImp.collection_post, renderer='json', accept='application/json')
         user_resource = add_resource(
             UserImp, collection_path='/users', path='/users/{id}',
             name='user_service', factory=dummy_factory)
@@ -123,7 +123,7 @@ class TestResource(TestCase):
         # the accept headers should work even in case they're specified in a
         # resource method
         self.assertEqual(
-            self.app.post("/users", headers={'Accept': 'text/json'},
+            self.app.post("/users", headers={'Accept': 'application/json'},
                           params=json.dumps({'test': 'yeah'})).json,
             {'test': 'yeah'})
 
@@ -184,7 +184,7 @@ class NonAutocommittingConfigurationTestResource(TestCase):
         add_view(UserImp.get, renderer='json')
         # pyramid does not allow having 2 views with same request conditions
         add_view(UserImp.get, renderer='jsonp', accept='application/javascript')
-        add_view(UserImp.collection_post, renderer='json', accept='text/json')
+        add_view(UserImp.collection_post, renderer='json', accept='application/json')
         user_resource = add_resource(
             UserImp, collection_path='/users', path='/users/{id}',
             name='user_service', factory=dummy_factory)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -58,7 +58,7 @@ class User(object):
     def get(self):
         return USERS.get(int(self.request.matchdict['id']))
 
-    @view(renderer='json', accept='text/json')
+    @view(renderer='json', accept='application/json')
     def collection_post(self):
         return {'test': 'yeah'}
 
@@ -126,7 +126,7 @@ class TestResource(TestCase):
         # the accept headers should work even in case they're specified in a
         # resource method
         self.assertEqual(
-            self.app.post("/users", headers={'Accept': 'text/json'},
+            self.app.post("/users", headers={'Accept': 'application/json'},
                           params=json.dumps({'test': 'yeah'})).json,
             {'test': 'yeah'})
 

--- a/tests/test_resource_callable.py
+++ b/tests/test_resource_callable.py
@@ -14,11 +14,11 @@ FRUITS = {1: {'name': 'apple'}, 2: {'name': 'orange'}}
 
 
 def _accept(request):
-    return ('text/json', 'application/json')
+    return ('text/plain', 'application/json')
 
 
 def _content_type(request):
-    return ('text/json', 'application/json')
+    return ('text/plain', 'application/json')
 
 
 @resource(collection_path='/fruits', path='/fruits/{id}',
@@ -58,15 +58,15 @@ class TestResource(TestCase):
 
     def test_accept_headers_get(self):
         self.assertEqual(
-            self.app.get("/fruits", headers={'Accept': 'text/json'}).json,
-            {'fruits': [1, 2]})
+            self.app.get("/fruits", headers={'Accept': 'text/plain'}).body,
+            b'{"fruits": [1, 2]}')
 
         self.assertEqual(
             self.app.get("/fruits", headers={'Accept': 'application/json'}).json,
             {'fruits': [1, 2]})
 
         self.assertEqual(
-            self.app.get("/fruits/1", headers={'Accept': 'text/json'}).json,
+            self.app.get("/fruits/1", headers={'Accept': 'text/plain'}).json,
             {'name': 'apple'})
 
         self.assertEqual(
@@ -76,7 +76,7 @@ class TestResource(TestCase):
 
     def test_accept_headers_post(self):
         self.assertEqual(
-            self.app.post("/fruits", headers={'Accept': 'text/json', 'Content-Type': 'application/json'},
+            self.app.post("/fruits", headers={'Accept': 'text/plain', 'Content-Type': 'application/json'},
                           params=json.dumps({'test': 'yeah'})).json,
             {'test': 'yeah'})
 
@@ -88,17 +88,17 @@ class TestResource(TestCase):
     def test_406(self):
             self.app.get(
                 "/fruits",
-                headers={'Accept': 'text/plain'},
+                headers={'Accept': 'text/xml'},
                 status=406)
 
             self.app.post(
                 "/fruits",
-                headers={'Accept': 'text/plain'},
+                headers={'Accept': 'text/html'},
                 params=json.dumps({'test': 'yeah'}),
                 status=406)
 
     def test_415(self):
         self.app.post(
             "/fruits",
-            headers={'Accept': 'application/json', 'Content-Type': 'text/plain'},
+            headers={'Accept': 'application/json', 'Content-Type': 'text/html'},
             status=415)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -186,7 +186,7 @@ class TestService(TestCase):
         # it is possible to give acceptable egress content-types dynamically at
         # run-time. You don't always want to have the callables when retrieving
         # all the acceptable content-types
-        service.add_view("POST", lambda x: "ok", accept=lambda r: "text/json")
+        service.add_view("POST", lambda x: "ok", accept=lambda r: "application/json")
         self.assertEqual(len(service.get_acceptable("POST")), 2)
         self.assertEqual(len(service.get_acceptable("POST", True)), 1)
 
@@ -215,7 +215,7 @@ class TestService(TestCase):
         # run-time. You don't always want to have the callables when retrieving
         # all the supported content-types
         service.add_view("POST", lambda x: "ok",
-                         content_type=lambda r: "text/json")
+                         content_type=lambda r: "application/json")
         self.assertEquals(len(service.get_contenttypes("POST")), 2)
         self.assertEquals(len(service.get_contenttypes("POST", True)), 1)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -89,7 +89,6 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         self.assertEquals('header', error_location)
         self.assertEquals('Accept', error_name)
         self.assertIn('application/json', error_description)
-        self.assertIn('text/json', error_description)
         self.assertIn('text/plain', error_description)
 
         # requesting a supported type should give an appropriate response type
@@ -118,20 +117,20 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         response = app.get('/service3', headers={'Accept': 'audio/*'},
                            status=406)
         error_description = response.json['errors'][0]['description']
-        self.assertIn('text/json', error_description)
+        self.assertIn('application/json', error_description)
 
         response = app.get('/service3', headers={'Accept': 'text/*'})
-        self.assertEqual(response.content_type, "text/json")
+        self.assertEqual(response.content_type, "text/plain")
 
         # Test that using a callable to define what's accepted works as well.
         # Now, the callable returns a scalar instead of a list.
         response = app.put('/service3', headers={'Accept': 'audio/*'},
                            status=406)
         error_description = response.json['errors'][0]['description']
-        self.assertIn('text/json', error_description)
+        self.assertIn('application/json', error_description)
 
         response = app.put('/service3', headers={'Accept': 'text/*'})
-        self.assertEqual(response.content_type, "text/json")
+        self.assertEqual(response.content_type, "text/plain")
 
         # If we are not asking for a particular content-type,
         # we should get one of the two types that the service supports.
@@ -143,7 +142,7 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         app = TestApp(main({}))
 
         response = app.get('/service3', headers={'Accept': 'text/*'})
-        self.assertEqual(response.content_type, "text/json")
+        self.assertEqual(response.content_type, "text/plain")
 
     def test_accept_issue_113_text_application_star(self):
         app = TestApp(main({}))

--- a/tests/validationapp.py
+++ b/tests/validationapp.py
@@ -57,7 +57,7 @@ def post1(request):
 service2 = Service(name="service2", path="/service2")
 
 
-@service2.get(accept=("application/json", "text/json"))
+@service2.get(accept=("application/json"))
 @service2.get(accept=("text/plain"), renderer="string")
 def get2(request):
     return {"body": "yay!"}
@@ -67,8 +67,8 @@ def get2(request):
 service3 = Service(name="service3", path="/service3")
 
 
-@service3.get(accept=lambda request: ('application/json', 'text/json'))
-@service3.put(accept=lambda request: 'text/json')
+@service3.get(accept=lambda request: ('application/json', 'text/plain'))
+@service3.put(accept=lambda request: ('application/json', 'text/plain'))
 def get3(request):
     return {"body": "yay!"}
 


### PR DESCRIPTION
Remove `text/json` - replace with `text/plain` and/or `application/json` according to each scenario.

Worth mentioning https://github.com/Cornices/cornice/issues/470#issuecomment-365315313