### PR TITLE
docs: add examples on how to reuse pyramid routes

### DIFF
--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -58,6 +58,17 @@ def add_resource(klass, depth=1, **kw):
             pass
 
         add_resource(User, collection_path='/users', path='/users/{id}')
+
+    Alternatively if you want to reuse your existing pyramid routes:
+
+    .. code-block:: python
+
+        class User(object):
+            pass
+
+        add_resource(User, collection_pyramid_route='users',
+            pyramid_route='user')
+
     """
 
     services = {}

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -68,6 +68,15 @@ As you can see, you can define methods for the collection (it will use the
 **path** argument of the class decorator. When defining collection_* methods, the
 path defined in the **collection_path** will be used.
 
+Here is an example how to reuse existing pyramid routes instead of registering
+new ones:
+
+.. code-block:: python
+
+   @resource(collection_pyramid_route='users', pyramid_route='user')
+   class User(object):
+       ....
+
 Validators and filters
 ======================
 

--- a/docs/source/services.rst
+++ b/docs/source/services.rst
@@ -16,6 +16,17 @@ this way:
     def flush_post(request):
         return {"Done": True}
 
+Example above registers new routes in pyramid registry, you might want to
+reuse existing routes from your application too.
+
+.. code-block:: python
+
+    from cornice import Service
+
+    flush = Service(name='flush',
+                    description='Clear database content',
+                    pyramid_route='flush_path')
+
 See :class:`cornice.service.Service` for an exhaustive list of options.
 
 Imperatively


### PR DESCRIPTION
This should make the feature complete with examples.