### PR TITLE
Fix DeprecationWarning for unrecognized backslash escapes

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -112,7 +112,7 @@ class Service(object):
 
     :param cors_origins:
         The list of origins for CORS. You can use wildcards here if needed,
-        e.g. ('list', 'of', '\*.domain').
+        e.g. ('list', 'of', '\\*.domain').
 
     :param cors_headers:
         The list of headers supported for the services.


### PR DESCRIPTION
This became a warning as of Python 3.6 -- see
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior.