### PR TITLE
Reducing simplejson use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     - python: 3.6
       env:
         - TOX_ENV=py36
+    - python: "3.7-dev"
+      env:
+        - TOX_ENV=py37
 
 notifications:
     irc:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGELOG
 3.5.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- cornice.errors and validation tests now use the builtin `json` module instead of `simplejson` (@okin)
 
 
 3.4.0 (2018-04-12)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -60,6 +60,7 @@ Cornice:
 * Matt Skinner <skinner.m.c@gmail.com>
 * Myroslav Opyr <myroslav@quintagroup.com>
 * Nicolas Dietrich <nicodietrich@gmail.com>
+* Niko Wenselowski <niko@nerdno.de>
 * Olivier Roussy <olivier@gandi.net>
 * Paul Smith <paulsmith@pobox.com>
 * Ralph Bean <rbean@redhat.com>

--- a/cornice/errors.py
+++ b/cornice/errors.py
@@ -26,7 +26,7 @@ class Errors(list):
     @classmethod
     def from_json(cls, string):
         """Transforms a json string into an `Errors` instance"""
-        obj = json.loads(string)
+        obj = json.loads(string.decode())
         return Errors.from_list(obj.get('errors', []))
 
     @classmethod

--- a/cornice/errors.py
+++ b/cornice/errors.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-import simplejson as json
+import json
 
 
 class Errors(list):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,13 +2,13 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
+import json
 import mock
 import unittest
 import warnings
 
 from pyramid import compat
 from pyramid.request import Request
-import simplejson as json
 from webtest import TestApp
 try:
     import colander


### PR DESCRIPTION
The aim of this is to make more use of the _json_ module from the standard library instead of the external _simplejson_ module.
This prepares closing #418 but because of problems mentioned in that issue this isn't yet a full switch.

It also enables tests with Python 3.7.