### PR TITLE
Silence another best_match warning

### DIFF
--- a/cornice/util.py
+++ b/cornice/util.py
@@ -112,7 +112,7 @@ def match_accept_header(func, context, request):
     """
     acceptable = to_list(func(request))
     request.info['acceptable'] = acceptable
-    return request.accept.best_match(acceptable) is not None
+    return len(request.accept.acceptable_offers(acceptable)) > 0
 
 
 def match_content_type_header(func, context, request):


### PR DESCRIPTION
Refs #498. I believe that this is the last remaining warning of this category now that Pyramid 1.10 is out with https://github.com/Pylons/pyramid/pull/3251/ in it.