### PR TITLE
Translate Error description field when it is a TranslationString type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGELOG
 3.5.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Translate Error description field when added with ``request.errors.add()`` (#502)
 
 
 3.4.4 (2018-12-12)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -79,6 +79,7 @@ Cornice:
 * Tarek Ziade <tarek@ziade.org>
 * Tim Tisdall <tisdall@gmail.com>
 * Tom Lazar <tomster@pyfidelity.com>
+* Tomasz Czekański <t.czekanski@gmail.com>
 * Tres Seaver <tseaver@palladion.com>
 * tsauerwein <tobias.sauerwein@camptocamp.com>
 * Victor Ng <crankycoder@gmail.com>

--- a/cornice/__init__.py
+++ b/cornice/__init__.py
@@ -74,6 +74,13 @@ def includeme(config):
     # attributes required to maintain services
     config.registry.cornice_services = {}
 
+    settings = config.get_settings()
+
+    # localization request subscriber must be set before first call
+    # for request.localizer (in wrap_request)
+    if settings.get('available_languages'):
+        setup_localization(config)
+
     config.add_directive('add_cornice_service', register_service_views)
     config.add_directive('add_cornice_resource', register_resource_views)
     config.add_subscriber(wrap_request, NewRequest)
@@ -81,7 +88,6 @@ def includeme(config):
     config.add_view_predicate('content_type', ContentTypePredicate)
     config.add_request_method(current_service, reify=True)
 
-    settings = config.get_settings()
     if asbool(settings.get('handle_exceptions', True)):
         config.add_view(handle_exceptions, context=Exception,
                         permission=NO_PERMISSION_REQUIRED)
@@ -89,6 +95,3 @@ def includeme(config):
                         permission=NO_PERMISSION_REQUIRED)
         config.add_view(handle_exceptions, context=HTTPForbidden,
                         permission=NO_PERMISSION_REQUIRED)
-
-    if settings.get('available_languages'):
-        setup_localization(config)

--- a/cornice/errors.py
+++ b/cornice/errors.py
@@ -3,12 +3,15 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
 
+from pyramid.i18n import TranslationString
+
 
 class Errors(list):
     """Holds Request errors
     """
-    def __init__(self, status=400):
+    def __init__(self, status=400, localizer=None):
         self.status = status
+        self.localizer = localizer
         super(Errors, self).__init__()
 
     def add(self, location, name=None, description=None, **kw):
@@ -17,6 +20,9 @@ class Errors(list):
                    'cookies', 'method')
         if location != '' and location not in allowed:
             raise ValueError('%r not in %s' % (location, allowed))
+
+        if isinstance(description, TranslationString) and self.localizer:
+            description = self.localizer.translate(description)
 
         self.append(dict(
             location=location,

--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -149,7 +149,7 @@ def wrap_request(event):
         setattr(request, 'validated', {})
 
     if not hasattr(request, 'errors'):
-        setattr(request, 'errors', Errors())
+        setattr(request, 'errors', Errors(localizer=request.localizer))
 
     if not hasattr(request, 'info'):
         setattr(request, 'info', {})

--- a/docs/source/i18n.rst
+++ b/docs/source/i18n.rst
@@ -1,0 +1,81 @@
+Internationalization and localization
+#####################################
+
+For internationalization and localization to work with your project you should
+follow instructions on Pyramid docs https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/i18n.html.
+
+You should also add two settings to you project .ini file:
+
+
+.. code-block:: python
+
+    pyramid.default_locale_name = en
+    available_languages = en fr pl
+
+
+There are few places where translations will be performed automatically for you
+by Cornice using `request.localizer.translate <https://docs.pylonsproject.org/projects/pyramid/en/latest/api/i18n.html#pyramid.i18n.Localizer.translate>`_
+function:
+
+    - Colander validation errors (standard validators and custom)
+    - Custom validation errors added with `request.errors.add(location, name, description, **kwars)`
+      (only `description` field will be translated)
+
+For custom error messages you are strongly advised to use 
+`TranslationString <https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/i18n.html#using-the-translationstring-class>`_
+from `pyramid.i18n` module.
+
+
+.. code-block:: python
+
+    from pyramid.i18n import TranslationString
+    ts = TranslationString('My error message')
+
+
+This applies to errors returned from Cornice validation:
+
+
+.. code-block:: python
+
+    ...
+
+    from pyramid.i18n import TranslationString
+
+    def custom_cornice_validator(request, **kwargs):
+        # do some validation and add an error
+        request.errors.add('body', 'field', TranslationString('My error message'))
+
+    @service.get(validators=custom_cornice_validator)
+    def service_handler(request):
+        return {}
+
+
+and Colander validation too:
+
+
+.. code-block:: python
+
+    ...
+
+    from pyramid.i18n import TranslationString
+
+
+    def custom_colander_validator(node, value):
+        # do some validation
+        request.errors.add('body', 'field', TranslationString('My error message'))
+
+    def MySchema(MappingSchema):
+        field = SchemaNode(String(), validator=custom_colander_validator)
+
+    @service.get(schema=MySchema(), validators=colander_body_validator)
+    def service_handler(request):
+        return {}
+
+
+You can also use factory for `TranslationString` as it makes your code easier
+to read. 
+
+
+.. seealso::
+
+    https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/i18n.html#using-the-translationstringfactory-class

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,6 +89,7 @@ Documentation content
    testing
    exhaustive_list
    api
+   i18n
    internals
    faq
    upgrading

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,12 @@
-from cornice.errors import Errors
+import mock
 
-from .support import TestCase
+from cornice.errors import Errors
+from cornice.service import Service
+from pyramid import testing
+from pyramid.i18n import TranslationString, Localizer
+from webtest import TestApp
+
+from .support import TestCase, CatchErrors
 
 
 class TestErrorsHelper(TestCase):
@@ -21,3 +27,39 @@ class TestErrorsHelper(TestCase):
     def test_raises_an_exception_when_location_is_unsupported(self):
         with self.assertRaises(ValueError):
             self.errors.add('something')
+
+
+service1 = Service(name="service1", path="/error-service1")
+
+@service1.get()
+def get1(request):
+    return request.errors.add('body', 'field', 'Description')
+
+
+service2 = Service(name="service2", path="/error-service2")
+
+@service2.get()
+def get2(request):
+    return request.errors.add('body', 'field', TranslationString('Description'))
+
+
+class TestErrorsTranslation(TestCase):
+
+    def setUp(self):
+        self.config = testing.setUp()
+        self.config.include('cornice')
+        self.config.scan('tests.test_errors')
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_error_description_translation_not_called_when_string(self):
+        with mock.patch('pyramid.i18n.Localizer.translate') as mocked:
+            resp = self.app.get('/error-service1', status=400).json
+            self.assertFalse(mocked.called)
+
+    def test_error_description_translation_called_when_translationstring(self):
+        with mock.patch('pyramid.i18n.Localizer.translate') as mocked:
+            resp = self.app.get('/error-service2', status=400).json
+            self.assertTrue(mocked.called)


### PR DESCRIPTION
When I add custom validation errors with `request.errors.add` method (eg. `request.errors.add('body', 'filed', _('Message'))` ) then cornice will not translate description for me. This behavior is not consistent with colander schema validation where messages are translated automatically with `request.localizer.translate` method.
This PR adds support for auto translation so it will not be necessary to call translation directly while passing description parameter to `request.errors.add`.