### PR TITLE
Update repository URL on docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -105,4 +105,4 @@ source, and this is one brick of our stack.
 We welcome Contributors and Feedback!
 
 - Developers Mailing List: https://mail.mozilla.org/listinfo/services-dev
-- Repository: https://github.com/mozilla-services/cornice
+- Repository: https://github.com/Cornices/cornice


### PR DESCRIPTION
It points to a `mozilla-services` github organization which is no longer the case.

The same goes with the mailing list, but I could not find where it is now, if there is any :confused: 