### PR TITLE
add validation support for multipart/form-data

### DIFF
--- a/cornice/validators/__init__.py
+++ b/cornice/validators/__init__.py
@@ -51,7 +51,7 @@ def extract_cstruct(request):
     """
     is_json = re.match('^application/(.*?)json$', str(request.content_type))
 
-    if request.content_type == 'application/x-www-form-urlencoded':
+    if request.content_type in ('application/x-www-form-urlencoded', 'multipart/form-data'):
         body = request.POST.mixed()
     elif request.content_type and not is_json:
         body = request.body

--- a/cornice/validators/__init__.py
+++ b/cornice/validators/__init__.py
@@ -51,7 +51,10 @@ def extract_cstruct(request):
     """
     is_json = re.match('^application/(.*?)json$', str(request.content_type))
 
-    if request.content_type in ('application/x-www-form-urlencoded', 'multipart/form-data'):
+    if request.content_type in (
+        'application/x-www-form-urlencoded', 
+        'multipart/form-data'
+    ):
         body = request.POST.mixed()
     elif request.content_type and not is_json:
         body = request.body

--- a/cornice/validators/__init__.py
+++ b/cornice/validators/__init__.py
@@ -52,7 +52,7 @@ def extract_cstruct(request):
     is_json = re.match('^application/(.*?)json$', str(request.content_type))
 
     if request.content_type in (
-        'application/x-www-form-urlencoded', 
+        'application/x-www-form-urlencoded',
         'multipart/form-data'
     ):
         body = request.POST.mixed()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -453,6 +453,22 @@ class TestRequestDataExtractors(LoggingCatcher, TestCase):
                             headers=headers)
         self.assertEqual(response.json['username'], 'man')
 
+    def test_multipart_form_data_one_field(self):
+        app = self.make_ordinary_app()
+        response = app.post('/signup',
+                            {'username': 'man'},
+                            content_type='multipart/form-data')
+        self.assertEqual(response.json['username'], 'man')
+
+    # Colander fails to parse multidict type return values
+    # Therefore, test requires different schema with multiple keys, '/form'
+    def test_multipart_form_data_multiple_fields(self):
+        app = self.make_ordinary_app()
+        response = app.post('/form',
+                            {'field1': 'man', 'field2': 'woman'},
+                            content_type='multipart/form-data')
+        self.assertEqual(response.json, {'field1': 'man', 'field2': 'woman'})
+
 
 @skip_if_no_colander
 class TestBoundSchemas(LoggingCatcher, TestCase):
@@ -737,6 +753,22 @@ class TestRequestDataExtractorsMarshmallow(LoggingCatcher, TestCase):
                             headers=headers)
         self.assertEqual(response.json['username'], 'man')
 
+    def test_multipart_form_data_one_field(self):
+        app = self.make_ordinary_app()
+        response = app.post('/m_signup',
+                            {'username': 'man'},
+                            content_type='multipart/form-data')
+        self.assertEqual(response.json['username'], 'man')
+    
+    # Marshmallow fails to parse multidict type return values
+    # Therefore, test requires different schema with multiple keys, '/m_form'
+    def test_multipart_form_data_multiple_fields(self):
+        app = self.make_ordinary_app()
+        response = app.post('/m_form',
+                            {'field1': 'man', 'field2': 'woman'},
+                            content_type='multipart/form-data')
+        self.assertEqual(response.json, {'field1': 'man', 'field2': 'woman'})
+    
 
 @skip_if_no_marshmallow
 class TestValidatorEdgeCasesMarshmallow(TestCase):

--- a/tests/validationapp.py
+++ b/tests/validationapp.py
@@ -174,6 +174,7 @@ if COLANDER:
     foobaz = Service(name="foobaz", path="/foobaz")
     email_service = Service(name='newsletter', path='/newsletter')
     item_service = Service(name='item', path='/item/{item_id}')
+    form_service = Service(name="form", path="/form")
 
 
     class SignupSchema(MappingSchema):
@@ -303,6 +304,16 @@ if COLANDER:
     def item(request):
         return request.validated['path']
 
+    class FormSchema(MappingSchema):
+        field1 = SchemaNode(String())
+        field2 = SchemaNode(String())
+
+
+    @form_service.post(schema=FormSchema(),
+                       validators=(colander_body_validator,))
+    def form(request):
+        return request.validated
+
 try:
     import marshmallow
     try:
@@ -328,6 +339,7 @@ if MARSHMALLOW:
     m_foobaz = Service(name="m_foobaz", path="/m_foobaz")
     m_email_service = Service(name='m_newsletter', path='/m_newsletter')
     m_item_service = Service(name='m_item', path='/m_item/{item_id}')
+    m_form_service = Service(name="m_form", path="/m_form")
 
 
     class MSignupSchema(marshmallow.Schema):
@@ -485,6 +497,19 @@ if MARSHMALLOW:
         schema=MItemSchema(), validators=(marshmallow_validator,))
     def m_item_fails(request):
         return request.validated['path']
+
+    class MFormSchema(marshmallow.Schema):
+        class Meta:
+            strict = True
+            unknown = EXCLUDE
+        field1 = marshmallow.fields.String()
+        field2 = marshmallow.fields.String()
+
+
+    @m_form_service.post(
+        schema=MFormSchema, validators=(marshmallow_body_validator,))
+    def m_form(request):
+        return request.validated
 
 def includeme(config):
     config.include("cornice")


### PR DESCRIPTION
The WebOb returned by `request.POST` supports boundary delimited `multipart/form-data` POSTs. This change merely calls the `mixed()` method on the `POST` body when the content-type is `multipart/form-data`, allowing validation to proceed in cases where the body is a combination of e.g. `json` and binary data.