### PR TITLE
Added wrapper for factory, ignoring OPTIONS requests when default options view used.

### DIFF
--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -163,7 +163,6 @@ def _ignore_options_factory_wrapper(factory):
     authorization header, which breaks some factories relying on user to be
     authenticated at the call point.
     """
-    @functools.wraps
     def _wrapper(request):
         if request.method == "OPTIONS":
             return


### PR DESCRIPTION
Basic example, demonstrating proposed way how to deal with factories being called during `OPTIONS` cors preflight request. See #451 https://github.com/Cornices/cornice/issues/451#issuecomment-523876630

I haven't added tests yet just because proposed approach might be incorrect and not worth putting efforts in it.