### PR TITLE
Support kwargs in marshmallow validator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGELOG
 3.7.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for passing keyword arguments to marshmallow validator.
 
 
 3.6.1 (2019-11-13)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -29,6 +29,7 @@ Cornice:
 * Gabriela Surita <gsurita@mozilla.com>
 * Gael Pasgrimaud <gael@gawel.org>
 * George V. Reilly <george@reilly.org>
+* George Mamalakis <mamalos@gmail.com>
 * Graham Higgins <gjh-github@bel-epa.com>
 * G.Tjebbes <g.t@majerti.fr>
 * Guillaume Gauvrit <guillaume@gandi.net>

--- a/cornice/validators/_marshmallow.py
+++ b/cornice/validators/_marshmallow.py
@@ -52,7 +52,7 @@ def _generate_marshmallow_validator(location):
         # see if the user wants to set any keyword arguments for their schema
         schema_kwargs = {}
         if 'schema_kwargs' in kwargs:
-            schema_kwargs = kwargs['schema_kwargs']
+            schema_kwargs = kwargs.get('schema_kwargs', {})
         schema = _instantiate_schema(schema, **schema_kwargs)
 
         class ValidatedField(marshmallow.fields.Field):

--- a/cornice/validators/_marshmallow.py
+++ b/cornice/validators/_marshmallow.py
@@ -50,9 +50,7 @@ def _generate_marshmallow_validator(location):
             return
 
         # see if the user wants to set any keyword arguments for their schema
-        schema_kwargs = {}
-        if 'schema_kwargs' in kwargs:
-            schema_kwargs = kwargs.get('schema_kwargs', {})
+        schema_kwargs = kwargs.get('schema_kwargs', {})
         schema = _instantiate_schema(schema, **schema_kwargs)
 
         class ValidatedField(marshmallow.fields.Field):

--- a/cornice/validators/_marshmallow.py
+++ b/cornice/validators/_marshmallow.py
@@ -27,7 +27,7 @@ def _generate_marshmallow_validator(location):
         the ``request.validated`` attribute.
 
         Keyword arguments to be included when initialising the marshmallow
-        schema can be passed as a dict in kwargs['schema_kwargs'] variable.
+        schema can be passed as a dict in ``kwargs['schema_kwargs']`` variable.
 
         .. note::
 

--- a/cornice/validators/_marshmallow.py
+++ b/cornice/validators/_marshmallow.py
@@ -26,6 +26,9 @@ def _generate_marshmallow_validator(location):
         The content of the location is deserialized, validated and stored in
         the ``request.validated`` attribute.
 
+        Keyword arguments to be included when initialising the marshmallow
+        schema can be passed as a dict in kwargs['schema_kwargs'] variable.
+
         .. note::
 
             If no schema is defined, this validator does nothing.
@@ -46,10 +49,14 @@ def _generate_marshmallow_validator(location):
         if schema is None:
             return
 
-        schema = _instantiate_schema(schema)
+        # see if the user wants to set any keyword arguments for their schema
+        schema_kwargs = {}
+        if 'schema_kwargs' in kwargs:
+            schema_kwargs = kwargs['schema_kwargs']
+        schema = _instantiate_schema(schema, **schema_kwargs)
 
         class ValidatedField(marshmallow.fields.Field):
-            def _deserialize(self, value, attr, data):
+            def _deserialize(self, value, attr, data, **kwargs):
                 schema.context.setdefault('request', request)
                 deserialized = schema.load(value)
                 # marshmallow 2.x returns a tuple, 3/x will always throw
@@ -185,8 +192,17 @@ def validator(request, schema=None, deserializer=None, **kwargs):
         request.validated.update(deserialized)
 
 
-def _instantiate_schema(schema):
+def _instantiate_schema(schema, **kwargs):
+    """
+    Returns an object of the given marshmallow schema.
+
+    :param schema: The marshmallow schema class with which the request should
+        be validated
+    :param kwargs: The keyword arguments that will be provided to the
+        marshmallow schema's constructor
+    :return: The object of the marshmallow schema
+    """
     if not inspect.isclass(schema):
         raise ValueError('You need to pass Marshmallow class instead '
                          'of schema instance')
-    return schema()
+    return schema(**kwargs)

--- a/tests/validationapp.py
+++ b/tests/validationapp.py
@@ -348,16 +348,6 @@ if MARSHMALLOW:
             unknown = EXCLUDE
         username = marshmallow.fields.String()
 
-    class MSignupGroupSchema(marshmallow.Schema):
-        class Meta:
-            strict = True
-            unknown = EXCLUDE
-        username = marshmallow.fields.String()
-
-        def __init__(self, *args, **kwargs):
-            kwargs['many'] = True
-            marshmallow.Schema.__init__(self, *args, **kwargs)
-
     import random
 
     class MNeedsContextSchema(marshmallow.Schema):
@@ -383,8 +373,15 @@ if MARSHMALLOW:
     def signup_post(request):
         return request.validated
 
-    @m_group_signup.post(
-        schema=MSignupGroupSchema, validators=(marshmallow_body_validator,))
+    # callback that returns a validator with keyword arguments for marshmallow
+    # schema initialisation. In our case it passes many=True to the desired
+    # schema
+    def get_my_marshmallow_validator_with_kwargs(request, **kwargs):
+        kwargs['schema'] = MSignupSchema
+        kwargs['schema_kwargs'] = {'many': True}
+        return marshmallow_body_validator(request, **kwargs)
+
+    @m_group_signup.post(validators=(get_my_marshmallow_validator_with_kwargs,))
     def m_group_signup_post(request):
         return {'data': request.validated}
 
@@ -510,6 +507,7 @@ if MARSHMALLOW:
         schema=MFormSchema, validators=(marshmallow_body_validator,))
     def m_form(request):
         return request.validated
+
 
 def includeme(config):
     config.include("cornice")


### PR DESCRIPTION
With this patch, keyword arguments are supported when instantiating the marshmallow schema (#511).

This is an example of how to use it:

```python
def my_validator(request, **kwargs):
    if request.method == 'POST':
        sch = MyPOSTSchema
        kwargs['schema_kwargs'] = {'many': True}
    elif request.method == 'PATCH':
        sch = MyPATCHSchema
    kwargs['schema'] = sch
    return marshmallow_body_validator(request, **kwargs)

class MyView(object):
    @view(validators=(my_validator,))
    def patch(self):
        return self._update()
```

So, if someone passes **schema_kwargs** dictionary in a marshmallow validator, it is expanded in the schema's constructor when it is instantiated.

Pinging @ergo for a second opinion.