### PR TITLE
Frame was always set to 2 for resource decorator.

### DIFF
--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -115,7 +115,7 @@ def add_resource(klass, depth=1, **kw):
                         klass.__name__.lower())
         service_name = prefix + service_name
         service = services[service_name] = Service(name=service_name,
-                                                   depth=2, **service_args)
+                                                   depth=depth, **service_args)
 
         # initialize views
         for verb in ('get', 'post', 'put', 'delete', 'options', 'patch'):


### PR DESCRIPTION
Which frame should be looked in defaults to 2 but was always 2 for resource decorator. This commit fixes this.