### PR TITLE
Drops simplejson as requirement

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -12,8 +12,13 @@ from cornice.validators import (
 )
 import venusian
 
-from cornice.util import is_string, to_list, json_error_handler, func_name
-
+from cornice.util import (
+    is_string,
+    to_list,
+    json_error_handler,
+    func_name,
+    default_bytes_adapter,
+)
 
 SERVICES = []
 
@@ -150,7 +155,7 @@ class Service(object):
     :meth:`~put`, :meth:`~options` and :meth:`~delete` are decorators that can
     be used to decorate views.
     """
-    renderer = 'simplejson'
+    renderer = 'cornicejson'
     default_validators = DEFAULT_VALIDATORS
     default_filters = DEFAULT_FILTERS
 
@@ -255,7 +260,8 @@ class Service(object):
             default_error_handler = json_error_handler(simplejson.dumps,
                                                        {"use_decimal": True})
         else:
-            default_error_handler = json_error_handler(json.dumps)
+            default_error_handler = json_error_handler(
+                json.dumps, {"default": default_bytes_adapter})
         # Allow custom error handler
         arguments['error_handler'] = conf.pop(
             'error_handler',

--- a/cornice/util.py
+++ b/cornice/util.py
@@ -11,15 +11,15 @@ from pyramid.renderers import IRendererFactory
 from pyramid.response import Response
 
 
-__all__ = ['is_string', 'json_renderer_factory', 'to_list', 'func_name',
-           'json_error_handler', 'match_accept_header']
+__all__ = ['is_string', 'json_renderer_factory', 'default_bytes_adapter',
+           'to_list', 'func_name', 'json_error_handler', 'match_accept_header']
 
 
 def is_string(s):
     return isinstance(s, string_types)
 
 
-def json_renderer_factory(simplejson_patch):
+def json_renderer_factory(simplejson_patch=False):
     def _json_renderer(helper):
         serializer_patch = None
         if simplejson_patch:
@@ -77,7 +77,6 @@ class _JsonRenderer(object):
             if 'use_decimal' not in renderer_factory.kw:
                 renderer_factory.kw['use_decimal'] = True
         renderer = renderer_factory(None)
-
         # XXX This call has the side effect of potentially setting the
         # ``response.content_type``.
         json_str = renderer(data, context)
@@ -94,6 +93,13 @@ def to_list(obj):
     """Convert an object to a list if it is not already one"""
     if not isinstance(obj, (list, tuple)):
         obj = [obj, ]
+    return obj
+
+
+def default_bytes_adapter(obj):
+    """Convert bytes objects to strings for json error renderer."""
+    if isinstance(obj, bytes):
+        return obj.decode('utf8')
     return obj
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
-requires = ['pyramid>=1.7',  'simplejson', 'six', 'venusian']
+requires = ['pyramid>=1.7', 'six', 'venusian']
 
 entry_points = ""
 package_data = {}

--- a/tests/support.py
+++ b/tests/support.py
@@ -3,6 +3,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 import logging.handlers
+import unittest
 import weakref
 
 try:
@@ -10,7 +11,6 @@ try:
 except ImportError:
     # Maybe we're running in python2.7?
     from unittest import TestCase  # NOQA
-
 from webob.dec import wsgify
 from webob import exc
 from pyramid.httpexceptions import HTTPException
@@ -18,6 +18,18 @@ from pyramid import testing
 
 from cornice.errors import Errors
 
+try:
+    import simplejson
+
+    SIMPLEJSON = True
+except ImportError:
+    SIMPLEJSON = False
+
+skip_if_no_simplejson = unittest.skipIf(SIMPLEJSON is False,
+                                        "simplejson is not installed.")
+
+skip_if_simplejson = unittest.skipIf(SIMPLEJSON is True,
+                                     "simplejson is installed.")
 
 logger = logging.getLogger('cornice')
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -61,6 +61,7 @@ class TestErrorsTranslation(TestCase):
             self.assertFalse(mocked.called)
 
     def test_error_description_translation_called_when_translationstring(self):
-        with mock.patch('pyramid.i18n.Localizer.translate') as mocked:
+        with mock.patch('pyramid.i18n.Localizer.translate',
+                        return_value="translated") as mocked:
             resp = self.app.get('/error-service2', status=400).json
             self.assertTrue(mocked.called)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-import simplejson
 from pyramid import testing
 from pyramid.interfaces import IRendererFactory
 from webtest import TestApp
@@ -9,7 +8,7 @@ import mock
 
 from cornice import Service
 from cornice.pyramidhook import apply_filters
-from .support import TestCase, CatchErrors
+from .support import TestCase, CatchErrors, skip_if_no_simplejson, skip_if_simplejson
 
 
 class TestCorniceSetup(TestCase):
@@ -29,7 +28,10 @@ class TestCorniceSetup(TestCase):
 
         return TestApp(CatchErrors(self.config.make_wsgi_app()))
 
+    @skip_if_no_simplejson
     def test_default_renderer_is_simplejson(self):
+        import simplejson
+
         self._get_app()
         self.assertEqual(Service.renderer, 'simplejson')
         renderer_factory = self.config.registry.queryUtility(
@@ -41,12 +43,12 @@ class TestCorniceSetup(TestCase):
             simplejson.dumps
         )
 
-    def test_default_renderer_is_configurable(self):
-        self.config.add_settings(cornice_default_renderer='myjson')
+    @skip_if_simplejson
+    def test_default_renderer_without_simplejson(self):
         self._get_app()
-        self.assertEqual(Service.renderer, 'myjson')
+        self.assertEqual(Service.renderer, 'cornicejson')
         renderer_factory = self.config.registry.queryUtility(
-            IRendererFactory, name='myjson'
+            IRendererFactory, name='cornicejson'
         )
         renderer = renderer_factory(None)
         self.assertIsNone(renderer._serializer_patch)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -13,7 +13,6 @@ from pyramid.httpexceptions import (
 from pyramid.exceptions import ConfigurationError
 from webtest import TestApp
 import mock
-from unittest import skip
 
 from cornice.resource import resource, view
 

--- a/tests/test_resource_callable.py
+++ b/tests/test_resource_callable.py
@@ -73,7 +73,6 @@ class TestResource(TestCase):
             self.app.get("/fruits/1", headers={'Accept': 'application/json'}).json,
             {'name': 'apple'})
 
-
     def test_accept_headers_post(self):
         self.assertEqual(
             self.app.post("/fruits", headers={'Accept': 'text/plain', 'Content-Type': 'application/json'},
@@ -86,16 +85,16 @@ class TestResource(TestCase):
             {'test': 'yeah'})
 
     def test_406(self):
-            self.app.get(
-                "/fruits",
-                headers={'Accept': 'text/xml'},
-                status=406)
+        self.app.get(
+            "/fruits",
+            headers={'Accept': 'text/xml'},
+            status=406)
 
-            self.app.post(
-                "/fruits",
-                headers={'Accept': 'text/html'},
-                params=json.dumps({'test': 'yeah'}),
-                status=406)
+        self.app.post(
+            "/fruits",
+            headers={'Accept': 'text/html'},
+            params=json.dumps({'test': 'yeah'}),
+            status=406)
 
     def test_415(self):
         self.app.post(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
-from unittest import mock
+import mock
 
 import simplejson
 from pyramid.exceptions import ConfigurationError

--- a/tests/test_service_definition.py
+++ b/tests/test_service_definition.py
@@ -21,7 +21,7 @@ def get1(request):
 
 @service1.post()
 def post1(request):
-    return {"body": request.body}
+    return {"body": request.body.decode('utf-8')}
 
 
 @service2.get(accept="text/html")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,7 +9,6 @@ from pyramid.interfaces import IRendererFactory
 from webtest import TestApp
 
 from cornice import util, Service
-from cornice.util import _JsonRenderer
 from .support import TestCase, CatchErrors
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ from pyramid.interfaces import IRendererFactory
 from webtest import TestApp
 
 from cornice import util, Service
+from cornice.util import default_bytes_adapter
 from .support import TestCase, CatchErrors, skip_if_no_simplejson, skip_if_simplejson
 
 
@@ -91,3 +92,13 @@ class JSONRendererTest(TestCase):
         # serializer should not have been patched
         self.assertEqual(json_renderer_factory.serializer, json.dumps)
         self.assertNotIn("use_decimal", json_renderer_factory.kw)
+
+    def test_default_bytes_adapter(self):
+        string = "test_string"
+        bytestring = b"test_string"
+        self.assertEqual(
+            default_bytes_adapter(string),
+            default_bytes_adapter(bytestring)
+        )
+        unsupported = object()
+        self.assertEqual(unsupported, default_bytes_adapter(unsupported))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,11 +1,19 @@
 # -*- encoding: utf-8 -*-
+import json
+
 import mock
-import unittest
+import simplejson
 
-from cornice import util
+from pyramid import testing
+from pyramid.interfaces import IRendererFactory
+from webtest import TestApp
+
+from cornice import util, Service
+from cornice.util import _JsonRenderer
+from .support import TestCase, CatchErrors
 
 
-class TestDeprecatedUtils(unittest.TestCase):
+class TestDeprecatedUtils(TestCase):
 
     def test_extract_json_data_is_deprecated(self):
         with mock.patch('cornice.util.warnings') as mocked:
@@ -18,7 +26,7 @@ class TestDeprecatedUtils(unittest.TestCase):
             self.assertTrue(mocked.warn.called)
 
 
-class CurrentServiceTest(unittest.TestCase):
+class CurrentServiceTest(TestCase):
 
     def test_current_service_returns_the_service_for_existing_patterns(self):
         request = mock.MagicMock()
@@ -33,3 +41,52 @@ class CurrentServiceTest(unittest.TestCase):
         request.registry.cornice_services = {}
 
         self.assertEqual(util.current_service(request), None)
+
+
+class JSONRendererTest(TestCase):
+    def setUp(self):
+        self.config = testing.setUp()
+        json_renderer_factory = self._get_json_renderer_factory()
+        json_renderer_factory.serializer = json.dumps
+        json_renderer_factory.kw = {}
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def _get_json_renderer_factory(self):
+        return self.config.registry.queryUtility(
+            IRendererFactory, name='json'
+        )
+
+    def _get_app(self):
+        self.config.include('cornice')
+
+        test_service = Service(name='testing', path='/test')
+        test_service.add_view('GET', lambda r: {"result": 1})
+        self.config.add_cornice_service(test_service)
+
+        return TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def test_default_renderer_gets_patched(self):
+        app = self._get_app()
+        response = app.get('/test')
+        self.assertEqual(response.text, '{"result": 1}')
+        json_renderer_factory = self._get_json_renderer_factory()
+
+        # serializer should have been patched
+        self.assertNotEqual(json_renderer_factory.serializer, json.dumps)
+        self.assertEqual(json_renderer_factory.serializer, simplejson.dumps)
+        self.assertIn("use_decimal", json_renderer_factory.kw)
+        self.assertTrue(json_renderer_factory.kw["use_decimal"])
+
+    def test_configured_renderer_does_not_get_patched(self):
+        self.config.add_settings(cornice_default_renderer='cornicejson')
+        app = self._get_app()
+        response = app.get('/test')
+        self.assertEqual(response.text, '{"result": 1}')
+        json_renderer_factory = self._get_json_renderer_factory()
+
+        # serializer should not have been patched
+        self.assertNotEqual(json_renderer_factory.serializer, simplejson.dumps)
+        self.assertEqual(json_renderer_factory.serializer, json.dumps)
+        self.assertNotIn("use_decimal", json_renderer_factory.kw)


### PR DESCRIPTION
Changes the name of the default renderer for Services to `'cornicejson'`. For retrocompatibility,
when simplejson is installed, the default renderer stays as `'simplejson'` and behaves
the same way it used to. Otherwise, the default pyramid serializer (`json.dumps(...)`) is used.