### PR TITLE
Refactors the rendering machinery of Cornice.

### DIFF
--- a/cornice/__init__.py
+++ b/cornice/__init__.py
@@ -5,8 +5,8 @@ import logging
 import pkg_resources
 from functools import partial
 
-from cornice import util
 from cornice.errors import Errors  # NOQA
+from cornice.renderer import CorniceRenderer
 from cornice.service import Service   # NOQA
 from cornice.pyramidhook import (
     wrap_request,
@@ -84,7 +84,7 @@ def includeme(config):
     config.add_directive('add_cornice_service', register_service_views)
     config.add_directive('add_cornice_resource', register_resource_views)
     config.add_subscriber(wrap_request, NewRequest)
-    config.add_renderer('simplejson', util.json_renderer)
+    config.add_renderer('cornice', CorniceRenderer())
     config.add_view_predicate('content_type', ContentTypePredicate)
     config.add_request_method(current_service, reify=True)
 

--- a/cornice/renderer.py
+++ b/cornice/renderer.py
@@ -1,0 +1,88 @@
+from pyramid import httpexceptions as exc
+from pyramid.renderers import JSON
+from pyramid.response import Response
+
+
+def bytes_adapter(obj, request):
+    """Convert bytes objects to strings for json error renderer."""
+    if isinstance(obj, bytes):
+        return obj.decode('utf8')
+    return obj
+
+
+class JSONError(exc.HTTPError):
+    def __init__(self, serializer, serializer_kw, errors, status=400):
+        body = {'status': 'error', 'errors': errors}
+        Response.__init__(self, serializer(body, **serializer_kw))
+        self.status = status
+        self.content_type = 'application/json'
+
+
+class CorniceRenderer(JSON):
+    """We implement JSON serialization by extending Pyramid's default
+    JSON rendering machinery using our own custom Content-Type logic `[1]`_.
+
+    This allows developers to config the JSON renderer using Pyramid's
+    configuration machinery `[2]`_.
+
+      .. _`[1]`: https://github.com/mozilla-services/cornice/pull/116 \
+                 #issuecomment-14355865
+      .. _`[2]`: http://pyramid.readthedocs.io/en/latest/narr/renderers.html \
+                 #serializing-custom-objects
+    """
+    acceptable = ('application/json', 'text/plain')
+
+    def __init__(self, *args, **kwargs):
+        """Adds a `bytes` adapter by default."""
+        super(CorniceRenderer, self).__init__(*args, **kwargs)
+        self.add_adapter(bytes, bytes_adapter)
+
+    def render_errors(self, request):
+        """Returns an HTTPError with the given status and message.
+
+        The HTTP error content type is "application/json"
+        """
+        default = self._make_default(request)
+        serializer_kw = self.kw.copy()
+        serializer_kw["default"] = default
+        return JSONError(
+            serializer=self.serializer,
+            serializer_kw=serializer_kw,
+            errors=request.errors,
+            status=request.errors.status
+        )
+
+    def render(self, value, system):
+        """Extends the default `_render` function of the pyramid JSON renderer.
+
+        Compared to the default `pyramid.renderers.JSON` renderer:
+            1. Overrides the response with an empty string and
+               no Content-Type in case of HTTP 204.
+            2. Overrides the default behavior of Content-Type handling,
+               forcing the use of `acceptable_offers`, instead of letting
+               the user specify the Content-Type manually.
+               TODO: maybe explain this a little better
+        """
+        request = system.get('request')
+        if request is not None:
+            response = request.response
+
+            # Do not return content with ``204 No Content``
+            if response.status_code == 204:
+                response.content_type = None
+                return ""
+
+            ctypes = request.accept.acceptable_offers(offers=self.acceptable)
+            if not ctypes:
+                ctypes = [(self.acceptable[0], 1.0)]
+            response.content_type = ctypes[0][0]
+        default = self._make_default(request)
+        return self.serializer(value, default=default, **self.kw)
+
+    def __call__(self, info):
+        """Overrides the default behavior of `pyramid.renderers.JSON`.
+
+        Uses a public `render()` method instead of defining render inside
+        `__call__`, to let the user extend it if necessary.
+        """
+        return self.render

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
-requires = ['pyramid>=1.7',  'simplejson', 'six', 'venusian']
+requires = ['pyramid>=1.7', 'six', 'venusian']
 
 entry_points = ""
 package_data = {}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,7 +3,7 @@ import mock
 from cornice.errors import Errors
 from cornice.service import Service
 from pyramid import testing
-from pyramid.i18n import TranslationString, Localizer
+from pyramid.i18n import TranslationString
 from webtest import TestApp
 
 from .support import TestCase, CatchErrors
@@ -55,12 +55,16 @@ class TestErrorsTranslation(TestCase):
     def tearDown(self):
         testing.tearDown()
 
+    @property
+    def _translate(self):
+        return "pyramid.i18n.Localizer.translate"
+
     def test_error_description_translation_not_called_when_string(self):
-        with mock.patch('pyramid.i18n.Localizer.translate') as mocked:
+        with mock.patch(self._translate) as mocked:
             resp = self.app.get('/error-service1', status=400).json
             self.assertFalse(mocked.called)
 
     def test_error_description_translation_called_when_translationstring(self):
-        with mock.patch('pyramid.i18n.Localizer.translate') as mocked:
+        with mock.patch(self._translate, return_value="Translated") as mocked:
             resp = self.app.get('/error-service2', status=400).json
             self.assertTrue(mocked.called)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,59 @@
+import mock
+from pyramid.interfaces import IJSONAdapter
+from pyramid.renderers import JSON
+from zope.interface import providedBy
+
+from cornice import CorniceRenderer
+from cornice.renderer import bytes_adapter, JSONError
+from .support import TestCase
+
+
+class TestBytesAdapter(TestCase):
+    def test_with_bytes_object(self):
+        self.assertEqual(bytes_adapter(b"hello", None), "hello")
+
+    def test_with_string_object(self):
+        self.assertEqual(bytes_adapter("hello", None), "hello")
+
+    def test_with_incompatible_object(self):
+        incompatible = object()
+        self.assertEqual(bytes_adapter(incompatible, None), incompatible)
+
+
+class TestRenderer(TestCase):
+    def test_renderer_is_pyramid_renderer_subclass(self):
+        self.assertIsInstance(CorniceRenderer(), JSON)
+
+    def test_renderer_has_bytes_adapter_by_default(self):
+        renderer = CorniceRenderer()
+        self.assertEqual(
+            renderer.components.adapters.lookup(
+                (providedBy(bytes()),),
+                IJSONAdapter
+            ),
+            bytes_adapter,
+        )
+
+    def test_renderer_calls_render_method(self):
+        renderer = CorniceRenderer()
+        self.assertEqual(renderer(info=None), renderer.render)
+
+    def test_renderer_render_errors(self):
+        renderer = CorniceRenderer()
+        request = mock.MagicMock()
+
+        class FakeErrors(object):
+            status = 418
+
+            def __json__(self, request):
+                return ["error_1", "error_2"]
+
+        request.errors = FakeErrors()
+
+        result = renderer.render_errors(request)
+        self.assertIsInstance(result, JSONError)
+        self.assertEqual(result.status_int, 418)
+        self.assertEqual(
+            result.json_body,
+            {"status": "error", "errors": ["error_1", "error_2"]}
+        )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -180,15 +180,15 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
     def test_override_default_accept_issue_252(self):
         # Override default acceptable content_types for interoperate with
         # legacy applications i.e. ExtJS 3.
-        from cornice.util import _JsonRenderer
-        _JsonRenderer.acceptable += ('text/html',)
+        from cornice.renderer import CorniceRenderer
+        CorniceRenderer.acceptable += ('text/html',)
 
         app = TestApp(main({}))
 
         response = app.get('/service5', headers={'Accept': 'text/html'})
         self.assertEqual(response.content_type, "text/html")
         # revert the override
-        _JsonRenderer.acceptable = _JsonRenderer.acceptable[:-1]
+        CorniceRenderer.acceptable = CorniceRenderer.acceptable[:-1]
 
     def test_filters(self):
         app = TestApp(main({}))


### PR DESCRIPTION
- Makes the default cornice renderer a subclass of :class:`pyramid.renderers.JSON`, so the default rendering machinery of pyramid is still supported, while keeping the Content-Type handling logic of cornice.
- Exposes the rendering logic in :method:`cornice.renderers.CorniceRenderer.render()`, so that it's customizable if needed.
- Rationalizes the error rendering on :class:`cornice.service.Service`, so that it uses the registered render to render `request.errors`, instead of a custom function.

**BREAKING**: the default renderer does not use `simplejson.dumps` by default anymore, so the requirement has been dropped.

Mentions #531 