### PR TITLE
Rename default renderer to cornicejson

### DIFF
--- a/cornice/__init__.py
+++ b/cornice/__init__.py
@@ -84,7 +84,7 @@ def includeme(config):
     config.add_directive('add_cornice_service', register_service_views)
     config.add_directive('add_cornice_resource', register_resource_views)
     config.add_subscriber(wrap_request, NewRequest)
-    config.add_renderer('cornice', CorniceRenderer())
+    config.add_renderer('cornicejson', CorniceRenderer())
     config.add_view_predicate('content_type', ContentTypePredicate)
     config.add_request_method(current_service, reify=True)
 

--- a/cornice/service.py
+++ b/cornice/service.py
@@ -53,7 +53,7 @@ class Service(object):
 
     :param renderer:
         The renderer that should be used by this service. Default value is
-        'cornice'.
+        'cornicejson'.
 
     :param description:
         The description of what the webservice does. This is primarily intended
@@ -149,7 +149,7 @@ class Service(object):
     :meth:`~put`, :meth:`~options` and :meth:`~delete` are decorators that can
     be used to decorate views.
     """
-    renderer = 'cornice'
+    renderer = 'cornicejson'
     default_validators = DEFAULT_VALIDATORS
     default_filters = DEFAULT_FILTERS
 


### PR DESCRIPTION
Some extensions like cornice.ext.swagger assume that JSON renderers
would contain the word ``"json"``.

Renaming this default renderer does not harm and kind of makes sense.

It does not mean we shouldn't fix the extensions to remove these sorts
of assumptions and be more robust.