### PR TITLE
Copy wrapped resource's attributes into the service

### DIFF
--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 import warnings
+import functools
 
 import venusian
 
@@ -116,6 +117,9 @@ def add_resource(klass, depth=1, **kw):
         service_name = prefix + service_name
         service = services[service_name] = Service(name=service_name,
                                                    depth=2, **service_args)
+        # ensure the service comes with the same properties as the wrapped
+        # resource
+        functools.update_wrapper(service, klass)
 
         # initialize views
         for verb in ('get', 'post', 'put', 'delete', 'options', 'patch'):


### PR DESCRIPTION
When a Service is generated from a Resource, it losses all the attributes from the resource (specifically the docstring). This change ensures that the wrapping service looks like it wrapped resource.

This is particularly useful since when I list the services registered by Cornice (`config.registry.cornice_services`), I need to have access to the original docstring.

Since the service is based on the resource, it makes also sense to mimic its attributes.