### PR TITLE
Fix Colander validator missing body, path, etc.

### DIFF
--- a/cornice/validators/_colander.py
+++ b/cornice/validators/_colander.py
@@ -74,7 +74,8 @@ def _generate_colander_validator(location):
         validator(request, RequestSchema(), deserializer, **kwargs)
         validated_location = request.validated.get(location, {})
         request.validated.update(validated_location)
-        request.validated.pop(location, None)
+        if location not in validated_location:
+            request.validated.pop(location, None)
 
     return _validator
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -427,6 +427,14 @@ class TestRequestDataExtractors(LoggingCatcher, TestCase):
             self.assertIn('Schema should inherit from colander.MappingSchema.',
                           str(context))
 
+    def test_json_body_attribute_is_not_lost(self):
+        app = self.make_ordinary_app()
+        response = app.post_json(
+            '/body_signup',
+            {'body': {'username': 'hey'}}
+        )
+        self.assertEqual(response.json['data'], {'body': {'username': 'hey'}})
+
     def test_json_array_with_colander_validator(self):
         app = self.make_ordinary_app()
         response = app.post_json(
@@ -770,7 +778,7 @@ class TestRequestDataExtractorsMarshmallow(LoggingCatcher, TestCase):
                             {'username': 'man'},
                             content_type='multipart/form-data')
         self.assertEqual(response.json['username'], 'man')
-    
+
     # Marshmallow fails to parse multidict type return values
     # Therefore, test requires different schema with multiple keys, '/m_form'
     def test_multipart_form_data_multiple_fields(self):
@@ -779,7 +787,7 @@ class TestRequestDataExtractorsMarshmallow(LoggingCatcher, TestCase):
                             {'field1': 'man', 'field2': 'woman'},
                             content_type='multipart/form-data')
         self.assertEqual(response.json, {'field1': 'man', 'field2': 'woman'})
-    
+
 
 @skip_if_no_marshmallow
 class TestValidatorEdgeCasesMarshmallow(TestCase):

--- a/tests/validationapp.py
+++ b/tests/validationapp.py
@@ -171,6 +171,7 @@ if COLANDER:
     bound = Service(name="bound", path="/bound")
     group_signup = Service(name="group signup", path="/group_signup")
     body_group_signup = Service(name="body_group signup", path="/body_group_signup")
+    body_signup = Service(name="body signup", path="/body_signup")
     foobar = Service(name="foobar", path="/foobar")
     foobaz = Service(name="foobaz", path="/foobaz")
     email_service = Service(name='newsletter', path='/newsletter')
@@ -222,6 +223,16 @@ if COLANDER:
                             validators=(colander_validator,))
     def body_group_signup_post(request):
         return {'data': request.validated['body']}
+
+
+    class BodySignupSchema(MappingSchema):
+        body = SignupSchema()
+
+    @body_signup.post(schema=BodySignupSchema(),
+                      validators=(colander_body_validator,))
+    def body_signup_post(request):
+        return {'data': request.validated}
+
 
     def validate_bar(node, value):
         if value != 'open':


### PR DESCRIPTION
The issue was introduced with commit
40ed37a2f453269ab85a4376914e893cf05d89c8

Validators that had attributes like `body` was broken
(`body` was missing in `request.validated`). For example:

```python
class EmailContentSchema(MappingSchema):
    subject = SchemaNode(String())
    body = SchemaNode(String())

@send_email_service.post(
    schema=EmailContentSchema(),
    validators=(colander_body_validator,),
)
def send_email_post(request):
    send_email(
        request.validated["subject"],
        request.validated["body"] # was missing
    )
    return HTTPOk()
```

The issue was with `body`, `headers`, `path`, `querystring` when using:
* `body_validator`
* `headers_validator`
* `path_validator`
* `querystring_validator`