### PR TITLE
Fix apply_filters where service defined by pyramid_route

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,10 @@ CHANGELOG
 
 - Drop support of Marshmallow < 3
 
+**Bug fixes**
+
+- Correctly determine service with pyramid route to ensure filters are applied and apply_cors_post_request is called
+
 
 5.2.0 (2021-04-06)
 ==================
@@ -53,7 +57,7 @@ CHANGELOG
 5.0.1 (2020-05-25)
 ==================
 
-- Add setuptoools ``python_requires`` check
+- Add setuptools ``python_requires`` check
 
 
 5.0.0 (2020-05-19)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Cornice:
 * Daniel M. Weeks <dan@danweeks.net>
 * David Charboneau <david@thecharboneaus.net>
 * David Grant <seizethedave@gmail.com>
+* Dion Peters <petersdion@gmail.com>
 * Elias <elias@stupeflix.com>
 * Gabriela Surita <gsurita@mozilla.com>
 * Gael Pasgrimaud <gael@gawel.org>
@@ -76,6 +77,7 @@ Cornice:
 * Ryan Kelly <ryan@rfk.id.au>
 * Scott Bowers <sbbowers@gmail.com>
 * Sebastian Hanula <sebastian.hanula@gmail.com>
+* Sergey Safonov <spoof@spoofa.info>
 * sghill <steve@sghill.net>
 * Simone Marzola <marzolasimone@gmail.com>
 * Tarek Ziade <tarek@ziade.org>
@@ -89,4 +91,3 @@ Cornice:
 * Ymage <o2heltem@gmail.com>
 * Volodymyr Maksymiv <vmaksymiv@quintagroup.com>
 * Walter Danilo Galante <walterdangalante@gmail.com>
-* Sergey Safonov <spoof@spoofa.info>

--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -14,7 +14,7 @@ from cornice.service import decorate_view
 from cornice.errors import Errors
 from cornice.util import (
     is_string, to_list, match_accept_header, match_content_type_header,
-    content_type_matches,
+    content_type_matches, current_service
 )
 from cornice.cors import (
     get_cors_validator,
@@ -98,9 +98,7 @@ def get_fallback_view(service):
 def apply_filters(request, response):
     if request.matched_route is not None:
         # do some sanity checking on the response using filters
-        services = request.registry.cornice_services
-        pattern = request.matched_route.pattern
-        service = services.get(pattern, None)
+        service = current_service(request)
         if service is not None:
             kwargs, ob = getattr(request, "cornice_args", ({}, None))
             for _filter in kwargs.get('filters', []):


### PR DESCRIPTION
Use current_service to determine cornice service in pyramidhook apply_filter, previously cornice service was not found if added via pyramid_route definition.