### PR TITLE
fix: eliminate deprecated marshmallow syntax

### DIFF
--- a/cornice/validators/_marshmallow.py
+++ b/cornice/validators/_marshmallow.py
@@ -80,7 +80,7 @@ def _generate_marshmallow_validator(location):
                 """
 
                 class_attrs[location] = ValidatedField(
-                    required=True, load_from=location)
+                    required=True, metadata={"load_from": location})
                 class_attrs['Meta'] = Meta
                 return type(name, bases, class_attrs)
 


### PR DESCRIPTION
After setting up a skeleton app, I was receiving a warning while running tests:

```
RemovedInMarshmallow4Warning: Passing field metadata as a keyword arg is deprecated. Use the explicit `metadata=...` argument instead.
```
The change here seems to fix the issue.
