### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,9 @@ CHANGELOG
 6.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+**Internal Changes**
+
+- Refactory ``unittest`` aliases for Python 3.11 compatibility
 
 
 6.0.0 (2021-09-29)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -46,6 +46,7 @@ Cornice:
 * Jon Staley <jon.staley@fundingoptions.com>
 * Joshua Immanuel <josh@hipro.co.in>
 * Josip Delic <delijati@googlemail.com>
+* Karthikeyan Singaravelan <tir.karthi@gmail.com>
 * Kit Randel <kit@nocturne.net.nz>
 * Laurence Rowe <laurence@lrowe.co.uk>
 * Lorenzo Gil Sanchez <lorenzo.gil.sanchez@gmail.com>

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -252,29 +252,29 @@ class TestService(TestCase):
         # be able to retrieve this information easily
         service = Service("color", "/favorite-color")
         service.add_view("GET", lambda x: "blue", content_type="text/plain")
-        self.assertEquals(service.get_contenttypes("GET"), ['text/plain'])
+        self.assertEqual(service.get_contenttypes("GET"), ['text/plain'])
 
         service.add_view("GET", lambda x: "blue",
                          content_type="application/json")
-        self.assertEquals(service.get_contenttypes("GET"),
-                          ['text/plain', 'application/json'])
+        self.assertEqual(service.get_contenttypes("GET"),
+                         ['text/plain', 'application/json'])
 
         # adding a view for the POST method should not break everything :-)
         service.add_view("POST", lambda x: "ok", content_type=('foo/bar'))
-        self.assertEquals(service.get_contenttypes("GET"),
-                          ['text/plain', 'application/json'])
+        self.assertEqual(service.get_contenttypes("GET"),
+                         ['text/plain', 'application/json'])
         # and of course the list of supported ingress content-types should be
         # available for the "POST" as well.
-        self.assertEquals(service.get_contenttypes("POST"),
-                          ['foo/bar'])
+        self.assertEqual(service.get_contenttypes("POST"),
+                         ['foo/bar'])
 
         # it is possible to give supported ingress content-types dynamically at
         # run-time. You don't always want to have the callables when retrieving
         # all the supported content-types
         service.add_view("POST", lambda x: "ok",
                          content_type=lambda r: "application/json")
-        self.assertEquals(len(service.get_contenttypes("POST")), 2)
-        self.assertEquals(len(service.get_contenttypes("POST", True)), 1)
+        self.assertEqual(len(service.get_contenttypes("POST")), 2)
+        self.assertEqual(len(service.get_contenttypes("POST", True)), 1)
 
     def test_get_validators(self):
         # defining different validators for the same services, even with

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -85,8 +85,8 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         error_location = response.json['errors'][0]['location']
         error_name = response.json['errors'][0]['name']
         error_description = response.json['errors'][0]['description']
-        self.assertEquals('header', error_location)
-        self.assertEquals('Accept', error_name)
+        self.assertEqual('header', error_location)
+        self.assertEqual('Accept', error_name)
         self.assertIn('application/json', error_description)
         self.assertIn('text/plain', error_description)
 
@@ -201,9 +201,9 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
 
         # it is possible to have more than one value with the same name in the
         # querystring
-        self.assertEquals(b'{"field": ["5"]}', app.get('/foobaz?field=5').body)
-        self.assertEquals(b'{"field": ["5", "2"]}',
-                          app.get('/foobaz?field=5&field=2').body)
+        self.assertEqual(b'{"field": ["5"]}', app.get('/foobaz?field=5').body)
+        self.assertEqual(b'{"field": ["5", "2"]}',
+                         app.get('/foobaz?field=5&field=2').body)
 
     def test_content_type_missing(self):
         # test that a Content-Type request headers is present
@@ -628,9 +628,9 @@ class TestServiceDefinitionMarshmallow(LoggingCatcher, TestCase):
 
         # it is possible to have more than one value with the same name in the
         # querystring
-        self.assertEquals(b'{"field": ["5"]}', app.get('/m_foobaz?field=5').body)
-        self.assertEquals(b'{"field": ["5", "2"]}',
-                          app.get('/m_foobaz?field=5&field=2').body)
+        self.assertEqual(b'{"field": ["5"]}', app.get('/m_foobaz?field=5').body)
+        self.assertEqual(b'{"field": ["5", "2"]}',
+                         app.get('/m_foobaz?field=5&field=2').body)
 
     def test_validated_body_content_from_schema(self):
         app = TestApp(main({}))


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268 