### PR TITLE
Update documentation for `Running tests`

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -11,11 +11,7 @@ just setup ``tox`` and run it inside the toplevel project directory::
 
 To run a single test inside a specific Python environment, do e.g.::
 
-    tox -e py27 tests/test_validation.py:TestServiceDefinition.test_content_type_missing
-
-or::
-
-    tox -e py27 tests.test_validation:TestServiceDefinition.test_content_type_missing
+    tox -e py39 tests/test_validation.py::TestServiceDefinition::test_content_type_missing
 
 
 Testing cornice services

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 [testenv]
 commands =
     python --version
-    pytest tests --cov-report term-missing --cov-fail-under 100 --cov cornice {posargs}
+    pytest {posargs: --cov-report term-missing --cov-fail-under 100 --cov cornice}
 deps =
     -rtests/requirements.txt
 install_command = pip install --pre {opts} {packages}
@@ -19,7 +19,7 @@ deps =
 install_command = pip install --pre {opts} {packages}
 commands =
     python --version
-    py.test {posargs}
+    pytest {posargs}
 
 [testenv:flake8]
 commands = flake8 cornice


### PR DESCRIPTION
- use Python 3.9 instead of unsupported Python 2.7
- update `tox` command to enable running a single test

Previously, all tests were selected and coverage ran, which makes no
sense if you only run one test.