### PR TITLE
Use TestCase.assertTrue() instead of TestCase.assert_()

### DIFF
--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -183,11 +183,11 @@ class TestResource(TestCase):
     def test_explicit_collection_service_name(self):
         route_url = testing.DummyRequest().route_url
         # service must exist
-        self.assert_(route_url('collection_user_service'))
+        self.assertTrue(route_url('collection_user_service'))
 
     def test_explicit_service_name(self):
         route_url = testing.DummyRequest().route_url
-        self.assert_(route_url('user_service', id=42))  # service must exist
+        self.assertTrue(route_url('user_service', id=42))  # service must exist
 
     @mock.patch('cornice.resource.Service')
     def test_factory_is_autowired(self, mocked_service):


### PR DESCRIPTION
The `assert_()` method is deprecated and will be removed in Python 3.12.

```
$ python3.11
Python 3.11.4 (main, Jun  7 2023, 00:00:00) [GCC 13.1.1 20230511 (Red Hat 13.1.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from unittest2 import TestCase
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'unittest2'
>>> from unittest import TestCase
>>> TestCase.assert_
<function TestCase._deprecate.<locals>.deprecated_func at 0x7fc1cf20eac0>
```

```
$ python3.12
Python 3.12.0b3 (main, Jun 21 2023, 00:00:00) [GCC 13.1.1 20230614 (Red Hat 13.1.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from unittest import TestCase
>>> TestCase.assert_
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'TestCase' has no attribute 'assert_'. Did you mean: 'assertIn'?
```