### PR TITLE
fix back-reference of dynamically created route for service by pyramihook

### DIFF
--- a/src/cornice/pyramidhook.py
+++ b/src/cornice/pyramidhook.py
@@ -181,6 +181,7 @@ def register_service_views(config, service):
         services["__cornice" + existing_route] = service
     else:
         services[prefix + service.path] = service
+        service.pyramid_route = route_name
 
     # before doing anything else, register a view for the OPTIONS method
     # if we need to


### PR DESCRIPTION
Using `config.route_prefix` and the `add_cornice_service` directive, I am able to register services that are used as decorators on pyramid view functions, with the appropriate prefix applied. So far, everything is ok. 

However, I am also using at the same time the https://github.com/Cornices/cornice.ext.swagger package, with the help of multiple extended definitions/converters in https://github.com/crim-ca/weaver/blob/master/weaver/wps_restapi/colander_extras.py, to auto-generate the OpenAPI 3.x definition represented by all the service paths, bodies, responses, etc. (relates to https://github.com/Cornices/cornice.ext.swagger/issues/133). 

When running the Swagger/OpenAPI generator, the service paths are resolved using the `Service.path` property. Since the services are configured with the non-prefixed path, and that prefixes are applied on the fly by `add_cornice_service`, I end up with incorrect paths whenever `config.route_prefix` is set to anything.  Looking deeper into the `cornice-swagger` code (i.e.: https://github.com/Cornices/cornice.ext.swagger/blob/609f923784d935ba5f497e9ebb87b8e5a21747a6/src/cornice_swagger/swagger.py#L571-L593), I find that the route-builder looks for `Service.pyramid_route` instead of using `Service.path` if it is defined, in case it could extract a predefined route (aka the name definition referenced by `config.add_route`).

Similarly, the pyramid `add_cornice_service` directive looks for that `Service.pyramid_route` in case it already exists to use it: 
https://github.com/Cornices/cornice/blob/677aa40771d08192409284ab0f4b7e7b55bb8e9f/src/cornice/pyramidhook.py#L169-L183

Now, the issue is that, when using `add_cornice_service` *WITHOUT* a predefined route, it creates one dynamically, but does not back-propagate this route reference onto the service. In order words, `services[prefix + service.path] = service` is set with the appropriate prefix, but the linked service in that dictionary still only has the `Service.path` reference without prefix. 

This PR applies the `route_name` that is expected to be created just a few lines after onto the `service.pyramid_route` property.
This way, `cornice-swagger` is able to correctly resolve the *prefixed* path of the service. 
https://github.com/Cornices/cornice/blob/677aa40771d08192409284ab0f4b7e7b55bb8e9f/src/cornice/pyramidhook.py#L224-L226




